### PR TITLE
[BUGFIX] fix player volume and playback rate bug

### DIFF
--- a/src/pages/ActivityCollectionPage.tsx
+++ b/src/pages/ActivityCollectionPage.tsx
@@ -26,7 +26,11 @@ const ActivityCollectionPage = () => {
   const { currentLanguage } = useContext(LanguageContext)
   const { pageTitle } = useNav()
   const { formatMessage } = useIntl()
+<<<<<<< HEAD
   const [active = null, setActive] = useQueryParam('categories', StringParam)
+=======
+  const [active = null, setActive] = useQueryParam('active', StringParam)
+>>>>>>> [HOTFIX] show activity if no query param
   const [noSelector] = useQueryParam('noSelector', BooleanParam)
   const { loadingActivities, errorActivities, activities } = usePublishedActivityCollection()
 

--- a/src/pages/ActivityCollectionPage.tsx
+++ b/src/pages/ActivityCollectionPage.tsx
@@ -26,11 +26,7 @@ const ActivityCollectionPage = () => {
   const { currentLanguage } = useContext(LanguageContext)
   const { pageTitle } = useNav()
   const { formatMessage } = useIntl()
-<<<<<<< HEAD
   const [active = null, setActive] = useQueryParam('categories', StringParam)
-=======
-  const [active = null, setActive] = useQueryParam('active', StringParam)
->>>>>>> [HOTFIX] show activity if no query param
   const [noSelector] = useQueryParam('noSelector', BooleanParam)
   const { loadingActivities, errorActivities, activities } = usePublishedActivityCollection()
 


### PR DESCRIPTION
這 PR 解掉底下這兩個 issue

1. 在播放時調快倍速後，跳到其他秒數，會變回原本的倍速
2. 調左右鍵控制播放軸，音量會變回初始值

順便 refactor 一下 localStroage 相關程式碼，換成統一的 function

## root cause

在移動時間軸的時候會觸發 canPlay 事件，就執行到了：

``` js
player.volume(config.volume)
player.playbackRate(config.playbackRate)
```

這時候的 config 是舊的，所以就用到舊的值了，就會回復成 1

目前解法是傳入 getConifg function 取代原本使用的 config，在要使用時從 localStorage 去拿，就能保證結果正確。VimeoPlayer 我就先沒調整了，一樣是用 config，想說這應該未來也會棄用，先保證現有行為就好。