### PR TITLE
[FEATURE] translation of new order status

### DIFF
--- a/src/components/sale/OrderCollectionAdminCard.tsx
+++ b/src/components/sale/OrderCollectionAdminCard.tsx
@@ -193,7 +193,7 @@ const OrderCollectionAdminCard: React.VFC<
 
       <div className="row">
         <div className="col-3 d-flex align-items-end">
-          {record.status !== 'SUCCESS' && record.status !== 'REFUND' && record.status !== 'EXPIRED' && (
+          {['UNPAID', 'PARTIAL_PAID', 'FAILED'].includes(record.status) && (
             <Button
               variant="outline"
               _hover={{

--- a/src/components/sale/OrderStatusTag.tsx
+++ b/src/components/sale/OrderStatusTag.tsx
@@ -33,6 +33,18 @@ const OrderStatusTag: React.FC<{
     case 'DELETED':
       statusTag = <Tag color="#72a7c1">{formatMessage(saleMessages.status.deleted)}</Tag>
       break
+    case 'PAYING':
+      statusTag = <Tag color="#ffbe1e">{formatMessage(saleMessages.status.paying)}</Tag>
+      break
+    case 'REFUNDING':
+      statusTag = <Tag color="#cdcdcd">{formatMessage(saleMessages.status.refunding)}</Tag>
+      break
+    case 'PARTIAL_EXPIRED':
+      statusTag = <Tag color="#cdcdcd">{formatMessage(saleMessages.status.partialExpired)}</Tag>
+      break
+    case 'UNKNOWN':
+      statusTag = <Tag color="#cdcdcd">{formatMessage(saleMessages.status.unknown)}</Tag>
+      break
   }
 
   return renderOrderStatusTag?.({ status, defaultStatusTag: statusTag }) || statusTag

--- a/src/helpers/translation.ts
+++ b/src/helpers/translation.ts
@@ -1327,6 +1327,10 @@ export const saleMessages = {
     refunded: { id: 'sale.status.refunded', defaultMessage: '已退款' },
     deleted: { id: 'sale.status.deleted', defaultMessage: '已刪除' },
     preparing: { id: 'sale.status.preparing', defaultMessage: '準備中' },
+    paying: { id: 'sale.status.paying', defaultMessage: '付款中' },
+    refunding: { id: 'sale.status.paying', defaultMessage: '退款中' },
+    partialExpired: { id: 'sale.status.partialExpired', defaultMessage: '部分過期' },
+    unknown: { id: 'sale.status.unknown', defaultMessage: '未知' },
   }),
 }
 
@@ -1680,11 +1684,11 @@ export const codeMessages = defineMessages({
   },
   E_PAYMENT_LIMIT: {
     id: 'code.E_PAYMENT_LIMIT',
-    defaultMessage: '付款次數已達十次上限',
+    defaultMessage: '付款次數已達十次上限，請建立新訂單',
   },
   E_COIN_INCLUDED: {
     id: 'code.E_COIN_INCLUDED',
-    defaultMessage: '無法建立含有代幣的交易',
+    defaultMessage: '無法建立含有代幣的交易，請移除該項目',
   },
   E_NO_PRICE: {
     id: 'code.E_NO_PRICE',


### PR DESCRIPTION
- show repay button when order status is one of 'UNPAID', 'PARTIAL_PAID', 'FAILED'
- translate new order status, error code