### PR TITLE
[FIX] hot-fix html2canvas CORS issue

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,7 +91,7 @@
     "env-cmd": "^10.1.0",
     "framer-motion": "2.9.4",
     "graphql-tag": "^2.12.5",
-    "html2canvas": "^1.4.1",
+    "html2canvas": "https://github.com/jhihruei/html2canvas.git#hotfix-cache",
     "husky": "4.3.8",
     "js-cookie": "^3.0.1",
     "jsonwebtoken": "8.5.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -8876,10 +8876,9 @@ html-webpack-plugin@4.5.0:
     tapable "^1.1.3"
     util.promisify "1.0.0"
 
-html2canvas@^1.4.1:
+"html2canvas@https://github.com/jhihruei/html2canvas.git#hotfix-cache":
   version "1.4.1"
-  resolved "https://registry.yarnpkg.com/html2canvas/-/html2canvas-1.4.1.tgz#7cef1888311b5011d507794a066041b14669a543"
-  integrity sha512-fPU6BHNpsyIhr8yyMpTLLxAbkaK8ArIBcmZIRiBLiDhjeqvXolaEmDGmELFuX9I4xDcaKKcJl+TKZLqruBbmWA==
+  resolved "https://github.com/jhihruei/html2canvas.git#1911b3ffebf24256f7a3fc9f471484131443b691"
   dependencies:
     css-line-break "^2.1.0"
     text-segmentation "^1.0.3"


### PR DESCRIPTION
Issue: screen capture doesn't contain background image in some cases. 

According to the issue report in https://github.com/niklasvh/html2canvas/issues/1544#issuecomment-435640901
It seems like a cache issue, which need to update `html2canvas` source code. 
I have forked the repo and patched, migrate to use the patched version and see if this issue could be resolved.

Patch: https://github.com/jhihruei/html2canvas/commit/1911b3ffebf24256f7a3fc9f471484131443b691