### PR TITLE
[FEATURE] merchandise list only display RadioCard when having different types 

### DIFF
--- a/src/pages/MerchandiseCollectionPage.tsx
+++ b/src/pages/MerchandiseCollectionPage.tsx
@@ -55,12 +55,13 @@ const MerchandiseCollectionPage: React.VFC = () => {
   const [isPhysical] = useQueryParam('isPhysical', BooleanParam)
   const { merchandises, merchandiseTags } = useMerchandiseCollection({
     search: keyword || '',
-    isPhysical: isPhysical !== undefined ? !!isPhysical : undefined,
     categories: categories ? categories : undefined,
   })
   const { pageTitle } = useNav()
 
-  const [selectCategory, setSelectCategory] = useState<string | null>(null)
+  const [selectCategory, setSelectCategory] = useState<string | null>(
+    isPhysical === undefined || isPhysical === null ? null : isPhysical ? 'isPhysical' : 'virtual',
+  )
   const [categoryId, setCategoryId] = useState<string | null>()
 
   const filteredMerchandises = merchandises

--- a/src/pages/MerchandiseCollectionPage.tsx
+++ b/src/pages/MerchandiseCollectionPage.tsx
@@ -93,6 +93,8 @@ const MerchandiseCollectionPage: React.VFC = () => {
         ? formatMessage(commonMessages.ui.physical)
         : formatMessage(commonMessages.ui.virtual),
     onChange: v => {
+      setCategoryId(null)
+
       const url = new URL(window.location.href)
       if (v === formatMessage(commonMessages.ui.all)) {
         url.searchParams.delete('isPhysical')

--- a/src/pages/MerchandiseCollectionPage.tsx
+++ b/src/pages/MerchandiseCollectionPage.tsx
@@ -71,7 +71,7 @@ const MerchandiseCollectionPage: React.VFC = () => {
   const filteredMerchandises = merchandises
     .filter(merchandise => !tag || merchandise.tags?.includes(tag))
     .filter(merchandise =>
-      selectCategory
+      selectCategory && hasDifferentMerchandiseType
         ? selectCategory === 'isPhysical'
           ? merchandise.isPhysical === true
           : merchandise.isPhysical === false

--- a/src/pages/MerchandiseCollectionPage.tsx
+++ b/src/pages/MerchandiseCollectionPage.tsx
@@ -64,6 +64,10 @@ const MerchandiseCollectionPage: React.VFC = () => {
   )
   const [categoryId, setCategoryId] = useState<string | null>()
 
+  const hasPhysical = merchandises.some(m => m.isPhysical)
+  const hasVirtual = merchandises.some(m => !m.isPhysical)
+  const hasDifferentMerchandiseType = hasPhysical && hasVirtual
+
   const filteredMerchandises = merchandises
     .filter(merchandise => !tag || merchandise.tags?.includes(tag))
     .filter(merchandise =>
@@ -184,14 +188,15 @@ const MerchandiseCollectionPage: React.VFC = () => {
               <Responsive.Default>
                 <div className="col-lg-4 mb-4">
                   <HStack className="mb-4" {...group}>
-                    {options.map(value => {
-                      const radio = getRadioProps({ value })
-                      return (
-                        <RadioCard key={value} size="md" {...radio}>
-                          {value}
-                        </RadioCard>
-                      )
-                    })}
+                    {hasDifferentMerchandiseType &&
+                      options.map(value => {
+                        const radio = getRadioProps({ value })
+                        return (
+                          <RadioCard key={value} size="md" {...radio}>
+                            {value}
+                          </RadioCard>
+                        )
+                      })}
                   </HStack>
                   <StyledCategoryList>
                     <li className="mb-2" onClick={() => setCategoryId(null)}>
@@ -231,14 +236,15 @@ const MerchandiseCollectionPage: React.VFC = () => {
             <Responsive.Desktop>
               <div className="col-lg-4">
                 <HStack className="mb-4" {...group}>
-                  {options.map(value => {
-                    const radio = getRadioProps({ value })
-                    return (
-                      <RadioCard key={value} size="md" {...radio}>
-                        {value}
-                      </RadioCard>
-                    )
-                  })}
+                  {hasDifferentMerchandiseType &&
+                    options.map(value => {
+                      const radio = getRadioProps({ value })
+                      return (
+                        <RadioCard key={value} size="md" {...radio}>
+                          {value}
+                        </RadioCard>
+                      )
+                    })}
                 </HStack>
                 <StyledCategoryList>
                   <li className="mb-2" onClick={() => setCategoryId(null)}>


### PR DESCRIPTION
### Bug fix
- Not filter by `isPhysical` when querying merchandises.
  - Because we need the whole merchandises list to know if they have virtual/physical merchandises and we only fetch data once for now, we should not filter merchandises by `isPhysical`.
- Reset categoryId when selected tab changed. 
  - The category might not always existing in both virtual and physical merchandises, we should reset category to avoid listing nothing after switch different tabs.

### Feature
- Hide RadioCard (virtual/physical tabs) when the merchandises only contain one of them. 
- Make the `isPhysical` in query string no work, if the  merchandises only contain one of virtual/physical. 