### PR TITLE
[UPDATE] Adjust PostCover position and image size

### DIFF
--- a/src/components/blog/PostCover.tsx
+++ b/src/components/blog/PostCover.tsx
@@ -25,11 +25,19 @@ const StyledPlayer = styled.div`
   background: black;
 `
 
-const StyledPictureCover = styled.div<{ pictureUrl: string }>`
-  height: 26rem;
-  background-image: url(${props => props.pictureUrl});
-  background-size: cover;
-  background-position: center;
+const StyledPictureCover = styled.div`
+  margin-bottom: 24px;
+
+  @media (max-width: 575px) {
+    margin-left: -15px;
+    margin-right: -15px;
+    margin-bottom: 40px;
+  }
+
+  img {
+    height: auto;
+    width: 100%;
+  }
 `
 const StyledVideoCover = styled.div<{ height?: number | null }>`
   background: black;
@@ -160,7 +168,8 @@ const PostCover: React.VFC<{
 
   if (type === 'picture') {
     return (
-      <StyledPictureCover id="post-cover" pictureUrl={coverUrl || EmptyCover}>
+      <StyledPictureCover id="post-cover">
+        <img src={coverUrl || EmptyCover} alt="cover" />
         {merchandiseModal}
       </StyledPictureCover>
     )

--- a/src/components/blog/PostLinkCollection.tsx
+++ b/src/components/blog/PostLinkCollection.tsx
@@ -24,15 +24,26 @@ export const PopularPostCollection: React.VFC = () => {
 
 export const RelativePostCollection: React.VFC<{ postId: string; tags?: string[] }> = ({ postId, tags }) => {
   const { formatMessage } = useIntl()
-  const { posts, postCount, fetchMorePost } = useRelativePostCollection(postId, tags)
-  const [page, setPage] = useState(0)
+  const { posts } = useRelativePostCollection(postId, tags)
 
   return (
-    <PostLinkCollection
-      title={posts.length ? formatMessage(messages.relative) : undefined}
-      posts={posts}
-      onFetchMore={posts.length < postCount ? () => fetchMorePost(page + 1).then(() => setPage(page + 1)) : undefined}
-    />
+    <div className="col-12">
+      <StyledTitle className="mb-3">{posts.length ? formatMessage(messages.relative) : undefined}</StyledTitle>
+      <div className="row">
+        {posts.slice(0, 3).map(post => (
+          <div key={post.id} className="col-12 col-sm-4 pb-2 mb-4">
+            <Link to={`/posts/${post.codeName || post.id}`}>
+              <div className="row">
+                <div className="mb-3 col-6 col-sm-12">
+                  <PostPreviewCover coverUrl={post.coverUrl} withVideo={typeof post.videoUrl === 'string'} />
+                </div>
+                <StyledPostTitle className="col-6 col-sm-12">{post.title}</StyledPostTitle>
+              </div>
+            </Link>
+          </div>
+        ))}
+      </div>
+    </div>
   )
 }
 

--- a/src/pages/BlogPostPage/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage/BlogPostPage.tsx
@@ -150,19 +150,19 @@ const BlogPostPage: React.VFC = () => {
   return (
     <DefaultLayout white noHeader={isScrollingDown}>
       <BlogPostPageHelmet post={post} />
-      {!loadingPost && (
-        <PostCover
-          title={post?.title || ''}
-          coverUrl={post?.videoUrl || post?.coverUrl || null}
-          type={post?.videoUrl ? 'video' : 'picture'}
-          merchandises={post?.merchandises || []}
-          isScrollingDown={isScrollingDown}
-        />
-      )}
 
-      <div className="container py-5">
+      <div className="container py-sm-5">
         <div className="row">
           <div className="col-12 col-lg-9">
+            {!loadingPost && (
+              <PostCover
+                title={post?.title || ''}
+                coverUrl={post?.videoUrl || post?.coverUrl || null}
+                type={post?.videoUrl ? 'video' : 'picture'}
+                merchandises={post?.merchandises || []}
+                isScrollingDown={isScrollingDown}
+              />
+            )}
             <StyledPostMeta className="pb-3">
               <Icon as={UserOIcon} className="mr-1" />
               <span className="mr-2">{post?.author.name}</span>

--- a/src/pages/BlogPostPage/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage/BlogPostPage.tsx
@@ -152,7 +152,7 @@ const BlogPostPage: React.VFC = () => {
       <BlogPostPageHelmet post={post} />
 
       <div className="container py-sm-5">
-        <div className="row">
+        <div className="row justify-content-center">
           <div className="col-12 col-lg-9">
             {!loadingPost && (
               <PostCover
@@ -229,6 +229,7 @@ const BlogPostPage: React.VFC = () => {
                 )}
               </div>
             </div>
+            <div className="row">{postId && <RelativePostCollection postId={postId} tags={post?.tags} />}</div>
             <div className="mb-4">
               <StyledPostTitle className="mb-3">{formatMessage(messages.blogSuggestion)}</StyledPostTitle>
               {currentMemberId && (
@@ -250,9 +251,6 @@ const BlogPostPage: React.VFC = () => {
                 </div>
               ))}
             </div>
-          </div>
-          <div className="col-12 col-lg-3 pl-4">
-            {postId && <RelativePostCollection postId={postId} tags={post?.tags} />}
           </div>
         </div>
       </div>


### PR DESCRIPTION
- Desktop
  <img width="1582" alt="截圖 2022-09-21 10 21 53" src="https://user-images.githubusercontent.com/6468997/191399856-190e6eb5-a84a-4394-8a00-fc1e85e92161.png">
  <img width="1582" alt="截圖 2022-09-21 10 21 26" src="https://user-images.githubusercontent.com/6468997/191399807-7bfad5a4-425e-454e-a3d0-d68a2ededbc9.png">

- Mobile
  <img width="648" alt="截圖 2022-09-21 10 23 56" src="https://user-images.githubusercontent.com/6468997/191400134-75c9d8c7-c1f8-4ec2-91a1-2077d8580c6a.png">
  <img width="648" alt="截圖 2022-09-21 10 24 02" src="https://user-images.githubusercontent.com/6468997/191400151-c0219e9e-eacf-40a6-916a-a4f2f559308a.png">

- Tablet
  <img width="767" alt="截圖 2022-09-21 10 25 09" src="https://user-images.githubusercontent.com/6468997/191400303-50e94b6d-7499-4d74-92bc-b76660086604.png">
  <img width="767" alt="截圖 2022-09-21 10 25 14" src="https://user-images.githubusercontent.com/6468997/191400317-731dab62-dc02-442f-8af8-ea97b3cb730d.png">

