### PR TITLE
[BUGFIX] Fix post cover image ratio and video preview size

### DIFF
--- a/src/components/blog/PostCover.tsx
+++ b/src/components/blog/PostCover.tsx
@@ -43,6 +43,7 @@ const StyledPictureCover = styled.div`
 `
 const StyledVideoCover = styled.div<{ height?: number | null }>`
   background: black;
+  margin-bottom: 24px;
 
   ${desktopViewMixin(css`
     padding: 2.5rem 0;
@@ -170,15 +171,19 @@ const PostCover: React.VFC<{
 
   if (type === 'picture') {
     return (
-      <StyledPictureCover id="post-cover">
-        <img src={coverUrl || EmptyCover} alt="cover" />
-        {merchandiseModal}
-      </StyledPictureCover>
+      <div className="container pt-sm-5">
+        <div className="row justify-content-center">
+          <StyledPictureCover id="post-cover" className="col-12 col-lg-9">
+            <img src={coverUrl || EmptyCover} alt="cover" />
+            {merchandiseModal}
+          </StyledPictureCover>
+        </div>
+      </div>
     )
   }
 
   return (
-    <StyledVideoCover ref={coverRef} id="post-cover" style={{ height: coverHeight ? `${coverHeight}px` : '' }}>
+    <StyledVideoCover ref={coverRef} id="post-cover" className="col-12 pt-sm-5" style={{ height: coverHeight ? `${coverHeight}px` : '' }}>
       <div className="container">
         <StyledVideoBlock
           className={`${!isClosed && isScrollingDown ? 'animated fadeInUp' : ''}`}

--- a/src/components/blog/PostCover.tsx
+++ b/src/components/blog/PostCover.tsx
@@ -37,6 +37,8 @@ const StyledPictureCover = styled.div`
   img {
     height: auto;
     width: 100%;
+    aspect-ratio: 16 / 9;
+    object-fit: cover;
   }
 `
 const StyledVideoCover = styled.div<{ height?: number | null }>`

--- a/src/pages/BlogPostPage/BlogPostPage.tsx
+++ b/src/pages/BlogPostPage/BlogPostPage.tsx
@@ -150,19 +150,18 @@ const BlogPostPage: React.VFC = () => {
   return (
     <DefaultLayout white noHeader={isScrollingDown}>
       <BlogPostPageHelmet post={post} />
-
-      <div className="container py-sm-5">
+      {!loadingPost && (
+        <PostCover
+          title={post?.title || ''}
+          coverUrl={post?.videoUrl || post?.coverUrl || null}
+          type={post?.videoUrl ? 'video' : 'picture'}
+          merchandises={post?.merchandises || []}
+          isScrollingDown={isScrollingDown}
+        />
+      )}
+      <div className="container pb-sm-5">
         <div className="row justify-content-center">
           <div className="col-12 col-lg-9">
-            {!loadingPost && (
-              <PostCover
-                title={post?.title || ''}
-                coverUrl={post?.videoUrl || post?.coverUrl || null}
-                type={post?.videoUrl ? 'video' : 'picture'}
-                merchandises={post?.merchandises || []}
-                isScrollingDown={isScrollingDown}
-              />
-            )}
             <StyledPostMeta className="pb-3">
               <Icon as={UserOIcon} className="mr-1" />
               <span className="mr-2">{post?.author.name}</span>


### PR DESCRIPTION
## Desktop 
- Video
  <img width="1470" alt="截圖 2022-10-06 02 12 38" src="https://user-images.githubusercontent.com/6468997/194132129-5d47ed3a-eba7-485a-96bf-e14e54697570.png">
  <img width="1470" alt="截圖 2022-10-06 02 12 41" src="https://user-images.githubusercontent.com/6468997/194132169-508bfbdb-2639-49ad-b2a1-84a27ed3a29c.png">
- Image with (almost) expected ratio
  <img width="1582" alt="截圖 2022-10-06 02 19 53" src="https://user-images.githubusercontent.com/6468997/194133411-852c0c35-e164-4a72-8e52-07470163808c.png">
- Image with unexpected ratio (1:1)
  <img width="1470" alt="截圖 2022-10-06 02 12 44" src="https://user-images.githubusercontent.com/6468997/194132179-1aad7d2a-f7d2-4e55-a83f-0450904f13bf.png">

----
## Tablet
- Video
  <img width="724" alt="截圖 2022-10-06 02 25 19" src="https://user-images.githubusercontent.com/6468997/194134449-535e54bf-2f88-4754-8b80-713a1b34a1d5.png">
- Image with (almost) expected ratio
  <img width="680" alt="截圖 2022-10-06 02 22 14" src="https://user-images.githubusercontent.com/6468997/194133924-18883920-dc4b-465e-870a-50beba182c68.png">
- Image with unexpected ratio (1:1)
  <img width="724" alt="截圖 2022-10-06 02 22 34" src="https://user-images.githubusercontent.com/6468997/194133929-ba9a950f-8ede-4726-8a27-cdc4da4739e2.png">

----
## Mobile
- Video
  <img width="724" alt="截圖 2022-10-06 02 23 23" src="https://user-images.githubusercontent.com/6468997/194134155-e7574a6b-9461-4b41-b61f-08ddcf8d91e8.png">
- Image with (almost) expected ratio
  <img width="724" alt="截圖 2022-10-06 02 23 33" src="https://user-images.githubusercontent.com/6468997/194134177-f45544c9-9959-4f78-89d3-11a08add9573.png">
- Image with unexpected ratio (1:1)
  <img width="724" alt="截圖 2022-10-06 02 23 38" src="https://user-images.githubusercontent.com/6468997/194134184-292a1cf8-2cc3-4cbc-ae55-44f70b29355a.png">
