### PR TITLE
[BUGFIX] prevent sending unneeded titleChange event

### DIFF
--- a/src/pages/AppPage/index.tsx
+++ b/src/pages/AppPage/index.tsx
@@ -143,35 +143,37 @@ const AppPage: React.VFC<{ renderFallback?: (path: string) => React.ReactElement
   }
   return (
     <>
-      <PageHelmet
-        title={appPage?.title || ''}
-        pageCraftData={appPage?.craftData}
-        pageMetaTag={appPage?.metaTag}
-        onLoaded={() => setMetaLoaded(true)}
-      />
       {metaLoaded && <Tracking.View />}
       {appPage ? (
-        <DefaultLayout {...appPage.options}>
-          {appPage.craftData ? (
-            <Editor enabled={false} resolver={CraftElement}>
-              <CraftBlock craftData={appPage.craftData} />
-            </Editor>
-          ) : (
-            <Editor enabled={false} resolver={CraftElement}>
-              <Frame>
-                <>
-                  {appPage.appPageSections.map(section => {
-                    const Section = sectionConverter[section.type]
-                    if (!sectionConverter[section.type]) {
-                      return null
-                    }
-                    return <Section key={section.id} options={section.options} />
-                  })}
-                </>
-              </Frame>
-            </Editor>
-          )}
-        </DefaultLayout>
+        <>
+          <PageHelmet
+            title={appPage?.title || ''}
+            pageCraftData={appPage?.craftData}
+            pageMetaTag={appPage?.metaTag}
+            onLoaded={() => setMetaLoaded(true)}
+          />
+          <DefaultLayout {...appPage.options}>
+            {appPage.craftData ? (
+              <Editor enabled={false} resolver={CraftElement}>
+                <CraftBlock craftData={appPage.craftData} />
+              </Editor>
+            ) : (
+              <Editor enabled={false} resolver={CraftElement}>
+                <Frame>
+                  <>
+                    {appPage.appPageSections.map(section => {
+                      const Section = sectionConverter[section.type]
+                      if (!sectionConverter[section.type]) {
+                        return null
+                      }
+                      return <Section key={section.id} options={section.options} />
+                    })}
+                  </>
+                </Frame>
+              </Editor>
+            )}
+          </DefaultLayout>
+        </>
       ) : renderFallback ? (
         renderFallback(location.pathname)
       ) : (

--- a/src/pages/ProgramPage/index.tsx
+++ b/src/pages/ProgramPage/index.tsx
@@ -80,7 +80,7 @@ const ProgramPage: React.VFC = () => {
   const { programId } = useParams<{ programId: string }>()
   const { pathname } = useLocation()
   const { currentMemberId } = useAuth()
-  const { id: appId, settings, enabledModules } = useApp()
+  const { id: appId, settings, enabledModules, loading: loadingApp } = useApp()
   const { resourceCollection } = useResourceCollection([`${appId}:program:${programId}`], true)
   const { visible } = useContext(PodcastPlayerContext)
   const { loadingProgram, program } = useProgram(programId)
@@ -137,7 +137,7 @@ const ProgramPage: React.VFC = () => {
 
   return (
     <DefaultLayout white footerBottomSpace={program.plans.length > 1 ? '60px' : '132px'}>
-      <ProgramPageHelmet program={program} onLoaded={() => setMetaLoaded(true)} />
+      {!loadingApp && <ProgramPageHelmet program={program} onLoaded={() => setMetaLoaded(true)} />}
       {resourceCollection[0] && metaLoaded && <Tracking.Detail resource={resourceCollection[0]} />}
 
       <div>


### PR DESCRIPTION
- only craft page directly use `PageHelmet` component
- send event when setting is loaded