### PR TITLE
[Bugfix] Blog detail style udpate

### DIFF
--- a/src/components/blog/FeaturingPostItem.tsx
+++ b/src/components/blog/FeaturingPostItem.tsx
@@ -21,7 +21,7 @@ const StyledWrapper = styled.div`
     bottom: 0;
     left: 0;
     content: ' ';
-    background-image: linear-gradient(to bottom, rgba(0, 0, 0, 0) 60%, black);
+    background-image: linear-gradient(rgba(0, 0, 0, 0) 25%, black);
   }
 `
 const StyledBody = styled.div`

--- a/src/components/blog/PostItemCollection.tsx
+++ b/src/components/blog/PostItemCollection.tsx
@@ -30,7 +30,8 @@ const PostItemCollection: React.VFC<{
   const { formatMessage } = useIntl()
   const [selectedCategoryId, setSelectedCategoryId] = useState<string | null>(null)
   const categories = uniqBy(category => category.id, posts.map(post => post.categories).flat())
-
+  console.log('selectedCategoryId', selectedCategoryId)
+  const displayPost = selectedCategoryId ? posts : posts.slice(3)
   return (
     <>
       {withTagSelector && (
@@ -59,7 +60,7 @@ const PostItemCollection: React.VFC<{
       )}
 
       <div className="row">
-        {posts
+        {displayPost
           .filter(post => !selectedCategoryId || post.categories.some(category => category.id === selectedCategoryId))
           .map(post => (
             <div key={post.id} className="col-6 col-lg-4 pb-2 mb-4">
@@ -67,7 +68,7 @@ const PostItemCollection: React.VFC<{
                 <div className="mb-3">
                   <PostPreviewCover coverUrl={post.coverUrl} withVideo={typeof post.videoUrl === 'string'} />
                 </div>
-                <StyledPostTitle>{post.title}</StyledPostTitle>
+                <StyledPostTitle rows={2}>{post.title}</StyledPostTitle>
                 <PostPreviewMeta authorId={post.authorId} publishedAt={post.publishedAt} />
               </Link>
             </div>

--- a/src/components/blog/index.tsx
+++ b/src/components/blog/index.tsx
@@ -47,11 +47,12 @@ export const StyledPostTitle = styled.div<{ rows?: number }>`
     }
     &.featuring {
       font-size: 16px;
-      font-weight: normal;
+      font-weight: 600;
+      margin-bottom: 4px;
     }
     &.list-item {
-      -webkit-line-clamp: 1;
-      height: 1.5em;
+      // -webkit-line-clamp: 1;
+      min-height: 1.5em;
       font-size: 20px;
     }
   `)}

--- a/src/pages/BlogPage.tsx
+++ b/src/pages/BlogPage.tsx
@@ -72,7 +72,7 @@ const BlogPage: React.VFC = () => {
 
           <div className="col-12 col-lg-9">
             <StyledTitle>{formatMessage(messages.latest)}</StyledTitle>
-            <PostItemCollection posts={posts.slice(3)} withTagSelector />
+            <PostItemCollection posts={posts} withTagSelector />
           </div>
         </div>
       </div>

--- a/src/pages/BlogPostCollectionPage.tsx
+++ b/src/pages/BlogPostCollectionPage.tsx
@@ -101,7 +101,7 @@ const BlogPostCollectionPage: React.VFC = () => {
                   />
                 </div>
                 <div className="col-6 col-lg-8 pl-3 pl-lg-4">
-                  <StyledPostTitle className="list-item">
+                  <StyledPostTitle className="list-item" rows={2}>
                     <Link to={`/posts/${post.codeName || post.id}`}>{post.title} </Link>
                   </StyledPostTitle>
                   <div className="mb-lg-4">


### PR DESCRIPTION
1.黑色遮罩拉高一點，調整成background-image: linear-gradient(rgba(0, 0, 0, 0) 25%, black)
2.標題變粗、下間距縮成4px
3.下方區塊的標題統一改顯示兩行
4.分類的設定
5.手機版標題設定