### PR TITLE
Revert "fix: update token"

### DIFF
--- a/src/pages/AppPage/index.tsx
+++ b/src/pages/AppPage/index.tsx
@@ -167,9 +167,7 @@ const AppPage: React.VFC<{ renderFallback?: (path: string) => React.ReactElement
             withCredentials: true,
           },
         )
-        if (code === 'SUCCESS') {
-          updateAuthToken?.(result.authToken)
-        } else {
+        if (code !== 'SUCCESS') {
           updateAuthToken?.(null)
         }
         if (code === 'E_NO_DEVICE') {


### PR DESCRIPTION
This reverts commit a583534481b55687fe5ce1893ab6bae6590a8963.

我改回原本的寫法歐 ～
這個 branch 在做的事情，只是讓有開 「裝置管理」 或 「登入上限」模組的客戶
在換頁的時候額外檢查當前的裝置有沒有被強制登出，因此只要去判斷 refresh token 回來的狀態是否為 success
如果不是的話需要把當前的 authtoken 清空 讓他登出

補充：原本 refresh token 只有在重整頁面、導向網站(例如：第一次進入網站、從其他金流頁面導回 lodestar) 的時候會去呼叫(可參考 [lodestar-app-element](https://github.com/urfit-tech/lodestar-app-element/blob/master/src/contexts/AppContext.tsx#L163-L168) )