### PR TITLE
[BUGFIX] fix MemberPage load ProgramCard slowly

### DIFF
--- a/src/hasura.d.ts
+++ b/src/hasura.d.ts
@@ -1876,6 +1876,50 @@ export interface GET_PROGRAM_IDS_BY_PROGRAM_PLAN_IDSVariables {
 // This file was automatically generated and should not be edited.
 
 // ====================================================
+// GraphQL query operation: GET_PROGRAM_PREVIEW
+// ====================================================
+
+export interface GET_PROGRAM_PREVIEW_program_by_pk_program_roles {
+  __typename: "program_role";
+  id: any;
+  /**
+   * instructor / assistant 
+   */
+  name: string;
+  member_id: string;
+}
+
+export interface GET_PROGRAM_PREVIEW_program_by_pk {
+  __typename: "program";
+  id: any;
+  cover_url: string | null;
+  cover_mobile_url: string | null;
+  cover_thumbnail_url: string | null;
+  title: string;
+  abstract: string | null;
+  /**
+   * An array relationship
+   */
+  program_roles: GET_PROGRAM_PREVIEW_program_by_pk_program_roles[];
+}
+
+export interface GET_PROGRAM_PREVIEW {
+  /**
+   * fetch data from the table: "program" using primary key columns
+   */
+  program_by_pk: GET_PROGRAM_PREVIEW_program_by_pk | null;
+}
+
+export interface GET_PROGRAM_PREVIEWVariables {
+  programId: any;
+}
+
+/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+// ====================================================
 // GraphQL query operation: GET_PROJECT_ENROLLMENT_COUNT
 // ====================================================
 

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -47,6 +47,16 @@ export type Program = ProgramBriefProps & {
   })[]
 }
 
+export type ProgramPreview = {
+  id: string
+  coverUrl: string | null
+  coverMobileUrl: string | null
+  coverThumbnailUrl: string | null
+  title: string
+  abstract: string | null
+  roles: ProgramRole[]
+}
+
 export type ProgramRole = {
   id: string
   name: ProgramRoleName


### PR DESCRIPTION
舊的方式：拿完全部的課程資料，進入課程內容頁不需再載入

新的方式：拿完所需的課程資料，進入課程內容頁再去拿該課程的全部資料

原本 src/containers/program/ProgramCard.tsx 用的是 useProgram
但其實根本不需要取那麼多資料

所以改寫成新的 useProgramPreview