### PR TITLE
fix: modify anchor default scroll position is top of CraftBlock

### DIFF
--- a/src/pages/AppPage/CraftBlock.tsx
+++ b/src/pages/AppPage/CraftBlock.tsx
@@ -29,7 +29,7 @@ const CraftBlock: React.VFC<{
       const id = hash.replace('#', '')
       const element = document.getElementById(id)
       if (element) {
-        element.scrollIntoView({ behavior: 'smooth', block: 'end' })
+        element.scrollIntoView({ behavior: 'smooth' })
       }
     }, 0)
   }, [hash])


### PR DESCRIPTION
- modify anchor default scroll position is top of CraftBlock

requirement:

頁面網址：

後台：https://www.xuemi.co/admin/craft-page/efced959-0b28-4ed9-8043-83324e752d8e

前台：https://www.xuemi.co/faq#faq-solve

敘述：使用錨點功能當區塊太長就會滑到正中間而不是該區塊的上方，尤其是這個區塊線上課程疑難排解（會滑到中間），詳見附圖