### PR TITLE
Fix/voucher groupbuying validate email

### DIFF
--- a/src/components/checkout/CheckoutBlock.tsx
+++ b/src/components/checkout/CheckoutBlock.tsx
@@ -191,7 +191,7 @@ const CheckoutBlock: React.VFC<{
   }>({})
   const [isGiftPlanDeliverable, setIsGiftPlanDeliverable] = useState(false)
 
-  const { memberId: referrerId, validateStatus } = useMemberValidation(referrerEmail)
+  const { memberId: referrerId, siteMemberValidateStatus } = useMemberValidation(referrerEmail)
 
   // checkout
   const [discountId, setDiscountId] = useState<string | null>(null)
@@ -318,10 +318,10 @@ const CheckoutBlock: React.VFC<{
       return
     }
 
-    if (settings['payment.referrer.type'] !== 'any' && referrerEmail && !validateStatus) {
+    if (settings['payment.referrer.type'] !== 'any' && referrerEmail && !siteMemberValidateStatus) {
       return
     }
-    if (settings['payment.referrer.type'] !== 'any' && validateStatus === 'error') {
+    if (settings['payment.referrer.type'] !== 'any' && siteMemberValidateStatus === 'error') {
       referrerRef.current?.scrollIntoView({ behavior: 'smooth' })
       return
     }
@@ -488,10 +488,10 @@ const CheckoutBlock: React.VFC<{
             </div>
             <div className="col-12 col-lg-6">
               <Form.Item
-                validateStatus={settings['payment.referrer.type'] === 'any' ? undefined : validateStatus}
+                validateStatus={settings['payment.referrer.type'] === 'any' ? undefined : siteMemberValidateStatus}
                 hasFeedback
                 help={
-                  settings['payment.referrer.type'] !== 'any' && validateStatus === 'error'
+                  settings['payment.referrer.type'] !== 'any' && siteMemberValidateStatus === 'error'
                     ? referrerId === currentMemberId
                       ? formatMessage(commonMessages.text.selfReferringIsNotAllowed)
                       : formatMessage(commonMessages.text.notFoundMemberEmail)
@@ -523,10 +523,10 @@ const CheckoutBlock: React.VFC<{
             </div>
             <div className="col-12 col-lg-6">
               <Form.Item
-                validateStatus={settings['payment.referrer.type'] === 'any' ? undefined : validateStatus}
+                validateStatus={settings['payment.referrer.type'] === 'any' ? undefined : siteMemberValidateStatus}
                 hasFeedback
                 help={
-                  settings['payment.referrer.type'] !== 'any' && validateStatus === 'error'
+                  settings['payment.referrer.type'] !== 'any' && siteMemberValidateStatus === 'error'
                     ? referrerId === currentMemberId
                       ? formatMessage(commonMessages.text.selfReferringIsNotAllowed)
                       : formatMessage(commonMessages.text.notFoundMemberEmail)

--- a/src/components/checkout/CheckoutBlock.tsx
+++ b/src/components/checkout/CheckoutBlock.tsx
@@ -492,7 +492,7 @@ const CheckoutBlock: React.VFC<{
                 hasFeedback
                 help={
                   settings['payment.referrer.type'] !== 'any' && siteMemberValidateStatus === 'error'
-                    ? referrerId === currentMemberId
+                    ? currentMemberId && referrerId === currentMemberId
                       ? formatMessage(commonMessages.text.selfReferringIsNotAllowed)
                       : formatMessage(commonMessages.text.notFoundMemberEmail)
                     : undefined
@@ -527,7 +527,7 @@ const CheckoutBlock: React.VFC<{
                 hasFeedback
                 help={
                   settings['payment.referrer.type'] !== 'any' && siteMemberValidateStatus === 'error'
-                    ? referrerId === currentMemberId
+                    ? currentMemberId && referrerId === currentMemberId
                       ? formatMessage(commonMessages.text.selfReferringIsNotAllowed)
                       : formatMessage(commonMessages.text.notFoundMemberEmail)
                     : undefined

--- a/src/components/checkout/CheckoutBlock.tsx
+++ b/src/components/checkout/CheckoutBlock.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Icon, Input, OrderedList, SkeletonText, useToast, Text } from '@chakra-ui/react'
+import { Box, Checkbox, Icon, Input, OrderedList, SkeletonText, useToast } from '@chakra-ui/react'
 import { defineMessage } from '@formatjs/intl'
 import { Form, message, Typography } from 'antd'
 import { CommonTitleMixin } from 'lodestar-app-element/src/components/common/'
@@ -318,10 +318,10 @@ const CheckoutBlock: React.VFC<{
       return
     }
 
-    if (referrerEmail && !validateStatus) {
+    if (settings['payment.referrer.type'] !== 'any' && referrerEmail && !validateStatus) {
       return
     }
-    if (validateStatus === 'error') {
+    if (settings['payment.referrer.type'] !== 'any' && validateStatus === 'error') {
       referrerRef.current?.scrollIntoView({ behavior: 'smooth' })
       return
     }
@@ -491,7 +491,7 @@ const CheckoutBlock: React.VFC<{
                 validateStatus={settings['payment.referrer.type'] === 'any' ? undefined : validateStatus}
                 hasFeedback
                 help={
-                  validateStatus === 'error'
+                  settings['payment.referrer.type'] !== 'any' && validateStatus === 'error'
                     ? referrerId === currentMemberId
                       ? formatMessage(commonMessages.text.selfReferringIsNotAllowed)
                       : formatMessage(commonMessages.text.notFoundMemberEmail)
@@ -526,7 +526,7 @@ const CheckoutBlock: React.VFC<{
                 validateStatus={settings['payment.referrer.type'] === 'any' ? undefined : validateStatus}
                 hasFeedback
                 help={
-                  validateStatus === 'error'
+                  settings['payment.referrer.type'] !== 'any' && validateStatus === 'error'
                     ? referrerId === currentMemberId
                       ? formatMessage(commonMessages.text.selfReferringIsNotAllowed)
                       : formatMessage(commonMessages.text.notFoundMemberEmail)

--- a/src/components/common/CommonForm.tsx
+++ b/src/components/common/CommonForm.tsx
@@ -5,10 +5,10 @@ import styled, { css } from 'styled-components'
 import { ReactComponent as CheckCircleIcon } from '../../images/checked-circle.svg'
 import { ReactComponent as ExclamationCircleIcon } from '../../images/exclamation-circle.svg'
 
-const StyledInput = styled(ChakraInput)<{ isSuccess: true }>`
+const StyledInput = styled(ChakraInput)<{ issuccess: 'true' }>`
   && {
     ${props =>
-      props.isSuccess &&
+      props.issuccess === 'true' &&
       css`
         border-color: var(--success);
         box-shadow: 0 0 0 1px var(--success);
@@ -47,7 +47,7 @@ const Input: React.VFC<
       <StyledInput
         isInvalid={status === 'error'}
         isDisabled={status === 'validating'}
-        isSuccess={status === 'success'}
+        issuccess={(status === 'success').toString()}
         focusBorderColor="primary.500"
         errorBorderColor="danger.500"
         {...inputProps}

--- a/src/components/common/CommonForm.tsx
+++ b/src/components/common/CommonForm.tsx
@@ -5,6 +5,8 @@ import styled, { css } from 'styled-components'
 import { ReactComponent as CheckCircleIcon } from '../../images/checked-circle.svg'
 import { ReactComponent as ExclamationCircleIcon } from '../../images/exclamation-circle.svg'
 
+type Status = 'error' | 'success'
+
 const StyledInput = styled(ChakraInput)<{ issuccess: 'true' }>`
   && {
     ${props =>
@@ -15,7 +17,7 @@ const StyledInput = styled(ChakraInput)<{ issuccess: 'true' }>`
       `}
   }
 `
-const StyledInputRightElement = styled(InputRightElement)<{ status: 'error' | 'success' }>`
+const StyledInputRightElement = styled(InputRightElement)<{ status: Status }>`
   && {
     font-size: 20px;
     ${props =>

--- a/src/components/common/CommonForm.tsx
+++ b/src/components/common/CommonForm.tsx
@@ -5,28 +5,31 @@ import styled, { css } from 'styled-components'
 import { ReactComponent as CheckCircleIcon } from '../../images/checked-circle.svg'
 import { ReactComponent as ExclamationCircleIcon } from '../../images/exclamation-circle.svg'
 
-type Status = 'error' | 'success'
+type Status = 'error' | 'validating' | 'success'
 
-const StyledInput = styled(ChakraInput)<{ issuccess: 'true' }>`
+// Todo: Can move Input style to lodestar-app-element but must check Input used components.
+
+const StyledInput = styled(ChakraInput)<{ variants: Status }>`
   && {
     ${props =>
-      props.issuccess === 'true' &&
+      props.variants === 'success' &&
       css`
         border-color: var(--success);
         box-shadow: 0 0 0 1px var(--success);
       `}
   }
 `
-const StyledInputRightElement = styled(InputRightElement)<{ status: Status }>`
+
+const StyledInputRightElement = styled(InputRightElement)<{ variants: Status }>`
   && {
     font-size: 20px;
     ${props =>
-      props.status === 'success' &&
+      props.variants === 'success' &&
       css`
         color: var(--success);
       `}
     ${props =>
-      props.status === 'error' &&
+      props.variants === 'error' &&
       css`
         color: var(--error);
       `}
@@ -35,7 +38,7 @@ const StyledInputRightElement = styled(InputRightElement)<{ status: Status }>`
 
 const Input: React.VFC<
   {
-    status?: 'error' | 'validating' | 'success'
+    status?: Status
   } & InputProps
 > = ({ status, ...inputProps }) => {
   const icon = {
@@ -46,15 +49,8 @@ const Input: React.VFC<
 
   return (
     <InputGroup>
-      <StyledInput
-        isInvalid={status === 'error'}
-        isDisabled={status === 'validating'}
-        issuccess={(status === 'success').toString()}
-        focusBorderColor="primary.500"
-        errorBorderColor="danger.500"
-        {...inputProps}
-      />
-      {status && icon[status] && <StyledInputRightElement status={status} children={<Icon as={icon[status]} />} />}
+      <StyledInput variants={status} focusBorderColor="primary.500" errorBorderColor="danger.500" {...inputProps} />
+      {status && icon[status] && <StyledInputRightElement variants={status} children={<Icon as={icon[status]} />} />}
     </InputGroup>
   )
 }

--- a/src/components/voucher/VoucherCollectionTabs.tsx
+++ b/src/components/voucher/VoucherCollectionTabs.tsx
@@ -1,12 +1,11 @@
 import { Tab, TabPanels, Tabs } from '@chakra-ui/react'
-import React, { useState } from 'react'
+import React from 'react'
 import { useIntl } from 'react-intl'
 import { usersMessages } from '../../helpers/translation'
 import { StyledTabList, StyledTabPanel } from '../../pages/GroupBuyingCollectionPage'
 import Voucher, { VoucherProps } from './Voucher'
 
 const VoucherCollectionTabs: React.VFC<{ vouchers: VoucherProps[] }> = ({ vouchers }) => {
-  const [activeKey, setActiveKey] = useState('available')
   const { formatMessage } = useIntl()
 
   const tabContents: {
@@ -41,15 +40,13 @@ const VoucherCollectionTabs: React.VFC<{ vouchers: VoucherProps[] }> = ({ vouche
     <Tabs colorScheme="primary">
       <StyledTabList>
         {tabContents.map(v => (
-          <Tab key={v.key} onClick={() => setActiveKey(v.key)} isSelected={v.key === activeKey}>
-            {v.name}
-          </Tab>
+          <Tab key={v.key}>{v.name}</Tab>
         ))}
       </StyledTabList>
 
       <TabPanels>
         {tabContents.map(v => (
-          <StyledTabPanel className="row">
+          <StyledTabPanel className="row" key={v.key}>
             {vouchers.filter(v.isDisplay).map(voucher => (
               <div key={voucher.id} className="col-12 col-lg-6">
                 <Voucher {...voucher} />

--- a/src/components/voucher/VoucherDeliverModal.tsx
+++ b/src/components/voucher/VoucherDeliverModal.tsx
@@ -7,6 +7,7 @@ import {
   FormLabel,
   InputGroup,
   InputRightElement,
+  Spinner,
   useDisclosure,
   useToast,
 } from '@chakra-ui/react'
@@ -179,6 +180,12 @@ const VoucherDeliverModal: React.VFC<{
             placeholder={formatMessage(commonMessages.text.fillInEnrolledEmail)}
             onBlur={e => setEmail(e.target.value)}
           />
+          {memberStatus === 'validating' && (
+            <>
+              <Spinner size="sm" mr="10px" />
+              {formatMessage(commonMessages.text.emailChecking)}
+            </>
+          )}
           <FormErrorMessage>
             {memberId === currentMemberId
               ? formatMessage(commonMessages.text.selfDeliver)

--- a/src/components/voucher/VoucherDeliverModal.tsx
+++ b/src/components/voucher/VoucherDeliverModal.tsx
@@ -101,6 +101,7 @@ const VoucherDeliverModal: React.VFC<{
             position: 'top',
           })
           onClose()
+          setEmail('')
         })
         .catch(handleError)
     }
@@ -172,6 +173,7 @@ const VoucherDeliverModal: React.VFC<{
           <Input
             type="email"
             status={memberStatus}
+            defaultValue={email}
             placeholder={formatMessage(commonMessages.text.fillInEnrolledEmail)}
             onBlur={e => setEmail(e.target.value)}
           />

--- a/src/components/voucher/VoucherDeliverModal.tsx
+++ b/src/components/voucher/VoucherDeliverModal.tsx
@@ -56,8 +56,8 @@ const VoucherDeliverModal: React.VFC<{
   const [redeemLinkChecking, setRedeemLinkChecking] = useState(false)
   const [redeemLink, setRedeemLink] = useState('')
 
-  const { memberId, validateStatus } = useMemberValidation(email)
-  const memberStatus = memberId === currentMemberId ? 'error' : validateStatus
+  const { memberId, siteMemberValidateStatus, isEmailInvalid } = useMemberValidation(email)
+  const memberStatus = memberId === currentMemberId ? 'error' : siteMemberValidateStatus
 
   const [updateVoucherMember] = useMutation<types.UPDATE_VOUCHER_MEMBER, types.UPDATE_VOUCHER_MEMBERVariables>(gql`
     mutation UPDATE_VOUCHER_MEMBER($voucherId: uuid!, $memberId: String!) {
@@ -123,7 +123,9 @@ const VoucherDeliverModal: React.VFC<{
             </Button>
             <Button
               colorScheme="primary"
-              isDisabled={memberId === currentMemberId || [undefined, 'error', 'validating'].includes(validateStatus)}
+              isDisabled={
+                memberId === currentMemberId || [undefined, 'error', 'validating'].includes(siteMemberValidateStatus)
+              }
               onClick={handleSubmit}
             >
               {formatMessage(commonMessages.ui.send)}
@@ -168,7 +170,7 @@ const VoucherDeliverModal: React.VFC<{
           </InputGroup>
         </FormControl>
         <StyledDivider>{formatMessage(commonMessages.defaults.or)}</StyledDivider>
-        <FormControl isInvalid={memberId === currentMemberId || validateStatus === 'error'}>
+        <FormControl isInvalid={memberId === currentMemberId || siteMemberValidateStatus === 'error'}>
           <FormLabel>{formatMessage(commonMessages.label.targetPartner)}</FormLabel>
           <Input
             type="email"
@@ -180,7 +182,9 @@ const VoucherDeliverModal: React.VFC<{
           <FormErrorMessage>
             {memberId === currentMemberId
               ? formatMessage(commonMessages.text.selfDeliver)
-              : validateStatus === 'error'
+              : isEmailInvalid
+              ? formatMessage(commonMessages.text.emailFormatError)
+              : siteMemberValidateStatus === 'error'
               ? formatMessage(commonMessages.text.notFoundMemberEmail)
               : undefined}
           </FormErrorMessage>

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -545,16 +545,13 @@ export const useMemberValidation = (email: string) => {
 
   const memberId: string | null = data?.member_public[0]?.id || null
 
-  const validateStatus: 'success' | 'error' | 'validating' | undefined =
-    settings['payment.referrer.type'] === 'any'
-      ? 'success'
-      : !email
-      ? undefined
-      : loading
-      ? 'validating'
-      : !memberId || memberId === currentMemberId
-      ? 'error'
-      : 'success'
+  const validateStatus: 'success' | 'error' | 'validating' | undefined = !email
+    ? undefined
+    : loading
+    ? 'validating'
+    : !memberId || memberId === currentMemberId
+    ? 'error'
+    : 'success'
 
   return {
     loadingMemberId: loading,

--- a/src/hooks/common.ts
+++ b/src/hooks/common.ts
@@ -542,22 +542,34 @@ export const useMemberValidation = (email: string) => {
     `,
     { variables: { email, appId } },
   )
-
+  const emailRegex = /^[\w-\.]+@([\w-]+\.)+[\w-]{2,}$/
+  const isEmailInvalid = !!email && !emailRegex.test(email)
   const memberId: string | null = data?.member_public[0]?.id || null
 
-  const validateStatus: 'success' | 'error' | 'validating' | undefined = !email
+  type Status = 'success' | 'error' | 'validating' | undefined
+
+  const siteMemberValidateStatus: Status = !email
     ? undefined
     : loading
     ? 'validating'
-    : !memberId || memberId === currentMemberId
+    : !memberId || memberId === currentMemberId || isEmailInvalid
+    ? 'error'
+    : 'success'
+
+  const nonMemberValidateStatus: Status = !email
+    ? undefined
+    : loading
+    ? 'validating'
+    : memberId === currentMemberId || isEmailInvalid
     ? 'error'
     : 'success'
 
   return {
-    loadingMemberId: loading,
     errorMemberId: error,
+    isEmailInvalid,
     memberId,
-    validateStatus,
+    siteMemberValidateStatus,
+    nonMemberValidateStatus,
     refetchMemberId: refetch,
   }
 }

--- a/src/pages/GroupBuyingCollectionPage/GroupBuyingDisplayCard.tsx
+++ b/src/pages/GroupBuyingCollectionPage/GroupBuyingDisplayCard.tsx
@@ -1,6 +1,5 @@
 import { gql, useMutation } from '@apollo/client'
 import {
-  Box,
   Button,
   ButtonGroup,
   Divider,
@@ -153,19 +152,20 @@ const GroupBuyingDeliverModal: React.VFC<{
             placeholder={formatMessage(commonMessages.text.fillInEnrolledEmail)}
             onBlur={e => setEmail(e.target.value)}
           />
+          {memberStatus === 'validating' && (
+            <>
+              <Spinner size="sm" mr="10px" />
+              {formatMessage(commonMessages.text.emailChecking)}
+            </>
+          )}
           <FormErrorMessage>
-            {isEmailInvalid ? (
-              formatMessage(commonMessages.text.emailFormatError)
-            ) : memberStatus === 'validating' ? (
-              <Box display="flex" alignItems="center">
-                <Spinner size="sm" mr="10px" />
-                {formatMessage(commonMessages.text.emailChecking)}
-              </Box>
-            ) : memberId === currentMemberId ? (
-              formatMessage(commonMessages.text.selfDeliver)
-            ) : partnerMemberIds.includes(memberId || '') ? (
-              formatMessage(commonMessages.text.delivered)
-            ) : undefined}
+            {isEmailInvalid
+              ? formatMessage(commonMessages.text.emailFormatError)
+              : memberId === currentMemberId
+              ? formatMessage(commonMessages.text.selfDeliver)
+              : partnerMemberIds.includes(memberId || '')
+              ? formatMessage(commonMessages.text.delivered)
+              : undefined}
           </FormErrorMessage>
         </FormControl>
       </CommonModal>

--- a/src/pages/GroupBuyingCollectionPage/index.tsx
+++ b/src/pages/GroupBuyingCollectionPage/index.tsx
@@ -3,7 +3,7 @@ import { Box, Flex, Image, Skeleton, Tab, TabList, TabPanel, TabPanels, Tabs } f
 import { EmptyBlock } from 'lodestar-app-element/src/components/common'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { uniq } from 'ramda'
-import React, { useState } from 'react'
+import React from 'react'
 import { defineMessages, useIntl } from 'react-intl'
 import styled from 'styled-components'
 import MemberAdminLayout from '../../components/layout/MemberAdminLayout'
@@ -56,8 +56,6 @@ const GroupBuyingCollectionPage: React.VFC = () => {
   const { currentMemberId } = useAuth()
   const { loading, error, groupBuyingOrderCollection, refetch } = useGroupBuyingLogs(currentMemberId)
 
-  const [tab, setTab] = useState('sendable')
-
   const tabContents: {
     key: string
     name: string
@@ -93,9 +91,7 @@ const GroupBuyingCollectionPage: React.VFC = () => {
       <Tabs colorScheme="primary">
         <StyledTabList>
           {tabContents.map(v => (
-            <Tab key={v.key} onClick={() => setTab(v.key)} isSelected={v.key === tab}>
-              {v.name}
-            </Tab>
+            <Tab key={v.key}>{v.name}</Tab>
           ))}
         </StyledTabList>
 
@@ -104,7 +100,7 @@ const GroupBuyingCollectionPage: React.VFC = () => {
             const displayOrders = groupBuyingOrderCollection.filter(v.isDisplay)
 
             return (
-              <StyledTabPanel>
+              <StyledTabPanel key={v.key}>
                 {loading || !currentMemberId ? (
                   <div className="row">
                     {Array.from(Array(9)).map((v, index) => (

--- a/src/pages/member/CouponCollectionAdminPage.tsx
+++ b/src/pages/member/CouponCollectionAdminPage.tsx
@@ -66,7 +66,7 @@ const CouponCollectionAdminPage: React.VFC = () => {
             </StyledTabList>
             <TabPanels>
               {tabContents.map(v => (
-                <StyledTabPanel className="row">
+                <StyledTabPanel className="row" key={v.key}>
                   {reverse(v.coupons).map(coupon => (
                     <div className="mb-3 col-12 col-md-6" key={coupon.id}>
                       <CouponAdminCard coupon={coupon} currentTab={v.key} />


### PR DESCRIPTION
- Fix the issue of the abnormal display of email validation in the VoucherDeliverModal and GroupBuyingDeliverModal.
- Fix the issue of the abnormal display when an email is not entered is incorrect in the VoucherDeliverModal and GroupBuyingDeliverModal.
- Fix the issue of the GroupBuyingDeliverModal's submit button not closing the modal.
- Fix the usage of Array.prototype.map() by adding the key prop.
- Remove the isSelected property from the Tab component.
- Change "isSucess" to "issuccess" (lowercase "s").
- Add the defaultValue of onBlur setEmail to the VoucherDeliverModal and GroupBuyingDeliverModal.
- Add the setEmail('') within the submit function of the VoucherDeliverModal and GroupBuyingDeliverModal.
- Fix the issue in the CheckoutBlock component where, in the absence of user login, entering any value in the referral field would display an error message saying '不可填寫自己的信箱' instead of '找不到這個註冊信箱'.