### PR TITLE
fix: add custom my page name & creator page name

### DIFF
--- a/src/components/layout/DefaultLayout/index.tsx
+++ b/src/components/layout/DefaultLayout/index.tsx
@@ -228,7 +228,7 @@ const DefaultLayout: React.FC<{
                         onClick={() => history.push(`/creators/${currentMemberId}`)}
                       >
                         <Link to={`/creators/${currentMemberId}`}>
-                          {formatMessage(commonMessages.button.creatorPage)}
+                          {settings['nav.creator_page.name'] || formatMessage(commonMessages.button.creatorPage)}
                         </Link>
                       </MenuButton>
                     </Menu>
@@ -248,7 +248,9 @@ const DefaultLayout: React.FC<{
                         }
                         onClick={() => history.push(`/members/${currentMemberId}`)}
                       >
-                        <Link to={`/members/${currentMemberId}`}>{formatMessage(commonMessages.button.myPage)}</Link>
+                        <Link to={`/members/${currentMemberId}`}>
+                          {settings['nav.my_page.name'] || formatMessage(commonMessages.button.myPage)}
+                        </Link>
                       </MenuButton>
                     </Menu>
                   )))}


### PR DESCRIPTION
requirement:

控制「我的主頁」字詞顯示： nav.my_page.name

ZZ已設定，但前台卻沒改變QQ

https://www.dogtorstray.com/

bug reason:

我之前再做合併的時候把自訂的我的主頁和創作者業給蓋過去了
所以導致修改參數設定 nav.my_page.name 的時候會無效