### PR TITLE
fix: resolve cached data in cart

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "libphonenumber-js": "1.9.34",
     "lint-staged": "10.5.4",
     "lodash": "^4.17.15",
-    "lodestar-app-element": "urfit-tech/lodestar-app-element#v1.52.0",
+    "lodestar-app-element": "urfit-tech/lodestar-app-element#2445c245d1ac7e2e95f726e4aca60159eca45945",
     "moment-timezone": "^0.5.31",
     "mustache": "^4.2.0",
     "organize-imports-cli": "0.7.0",

--- a/src/components/checkout/CheckoutBlock.tsx
+++ b/src/components/checkout/CheckoutBlock.tsx
@@ -1,4 +1,4 @@
-import { Box, Checkbox, Icon, Input, OrderedList, SkeletonText, useToast, Text } from '@chakra-ui/react'
+import { Box, Checkbox, Icon, Input, OrderedList, SkeletonText, useToast } from '@chakra-ui/react'
 import { defineMessage } from '@formatjs/intl'
 import { Form, message, Typography } from 'antd'
 import { CommonTitleMixin } from 'lodestar-app-element/src/components/common/'
@@ -92,10 +92,13 @@ const CheckoutBlock: React.VFC<{
   const { setVisible } = useContext(AuthModalContext)
   const { removeCartProducts } = useContext(CartContext)
   const { memberShop } = useMemberShop(shopId)
-  const [isApproved, setIsApproved] = useState(settings['checkout.approvement'] !== 'true')
+  const [isApproved, setIsApproved] = useState(localStorage.getItem('kolable.checkout.approvement') === 'true')
+
+  // 讓「我同意」按鈕在使用者重新進入後保持一樣
   useEffect(() => {
-    setIsApproved(settings['checkout.approvement'] !== 'true')
-  }, [settings])
+    localStorage.setItem('kolable.checkout.approvement', JSON.stringify(isApproved))
+    setIsApproved(localStorage.getItem('kolable.checkout.approvement') === 'true')
+  }, [isApproved])
 
   const updateMemberMetadata = useUpdateMemberMetadata()
   const toast = useToast()

--- a/yarn.lock
+++ b/yarn.lock
@@ -11394,9 +11394,9 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodestar-app-element@urfit-tech/lodestar-app-element#v1.52.0:
+lodestar-app-element@urfit-tech/lodestar-app-element#2445c245d1ac7e2e95f726e4aca60159eca45945:
   version "0.1.0"
-  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/5618d2672b405edb3840bd28d4be27b2c6e80167"
+  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/2445c245d1ac7e2e95f726e4aca60159eca45945"
   dependencies:
     "@apollo/client" "^3.7.11"
     "@bobthered/tailwindcss-palette-generator" "2.0.0"


### PR DESCRIPTION
1. notice that '付款方式' ‘我同意’ wouldn't keep data after user reload the page.
2. add 'kolable.checkout.approvement' to LocalStorage to store the value.
3. add lodestar-app-element #2445c245d1ac7e2e95f726e4aca60159eca45945 to the repo, to fix  '付款方式''s problem