### PR TITLE
fix: modify picture size in BlogPostCollectionPage

### DIFF
--- a/src/pages/BlogPostCollectionPage.tsx
+++ b/src/pages/BlogPostCollectionPage.tsx
@@ -97,7 +97,7 @@ const BlogPostCollectionPage: React.VFC = () => {
               >
                 <div className="col-6 col-lg-4">
                   <PostPreviewCover
-                    variant="list-item"
+                    variant="featuring"
                     coverUrl={post.coverUrl}
                     withVideo={typeof post.videoUrl === 'string'}
                   />


### PR DESCRIPTION
requirement: 「在 blog 的頁面中，封面圖片的 div 寬高和建議尺寸不合。建議尺寸是 1200 \ *675，也就是 width * 0.5625，但是不知道為什麼元件的寫法是 width * 0.6666666。這邊需要協助修正。」

1. modify the variant of component PostPreviewCover
   variant: “list-item“ → “featuring“