### PR TITLE
fix: modify PodcastPlayerContext play mode

### DIFF
--- a/src/contexts/PodcastPlayerContext.tsx
+++ b/src/contexts/PodcastPlayerContext.tsx
@@ -68,6 +68,7 @@ export const PodcastPlayerProvider: React.FC = ({ children }) => {
   const [duration, setDuration] = useState(0)
   // const { podcastProgramProgress, refetchPodcastProgramProgress } = usePodcastProgramProgress(currentPodcastProgramId)
   const [progress, setProgress] = useState(0)
+  const [hadPlayedIndexList, setHadPlayedIndexList] = useState<number[]>([])
 
   useEffect(() => {
     localStorage.setItem('podcast.rate', JSON.stringify(rate))
@@ -82,6 +83,7 @@ export const PodcastPlayerProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     localStorage.setItem('podcastProgramIds', JSON.stringify(podcastProgramIds))
+    setHadPlayedIndexList([])
   }, [podcastProgramIds])
 
   useEffect(() => {
@@ -91,6 +93,7 @@ export const PodcastPlayerProvider: React.FC = ({ children }) => {
 
   useEffect(() => {
     localStorage.setItem('podcastAlbumId', podcastAlbumId)
+    setHadPlayedIndexList([])
   }, [podcastAlbumId])
 
   useInterval(() => {
@@ -125,11 +128,28 @@ export const PodcastPlayerProvider: React.FC = ({ children }) => {
         onPause={() => setPlaying(false)}
         onEnded={() => {
           if (modeRef.current === 'loop') {
-            setCurrentIndex(index => (index + 1) % podcastProgramIds.length)
+            podcastProgramIds.length === 1
+              ? setPlaying(true)
+              : setCurrentIndex(index => (index + 1) % podcastProgramIds.length)
           } else if (modeRef.current === 'random') {
-            setCurrentIndex(
-              index => (index + Math.floor(Math.random() * (podcastProgramIds.length - 1))) % podcastProgramIds.length,
-            )
+            setCurrentIndex(index => {
+              let currentHadPlayedIndexList = [...hadPlayedIndexList, index]
+              if (currentHadPlayedIndexList.length === podcastProgramIds.length) {
+                currentHadPlayedIndexList = []
+                setHadPlayedIndexList([])
+              } else {
+                setHadPlayedIndexList(indexList => [...indexList, index])
+              }
+
+              let nextIndex = -1
+              let isPlayedIndex = true
+              while (isPlayedIndex) {
+                nextIndex =
+                  (index + Math.floor(Math.random() * (podcastProgramIds.length - 1))) % podcastProgramIds.length
+                isPlayedIndex = currentHadPlayedIndexList.includes(nextIndex)
+              }
+              return nextIndex
+            })
           }
         }}
       />


### PR DESCRIPTION
- modify PodcastPlayerContext play mode

requirement:
專輯：
https://demo.lodestar-dev.cc/podcast-albums/dd54e5a5-b99b-46fa-80d0-5ee64a4c2eb9

單曲：
https://demo.lodestar-dev.cc/podcasts/349d2a83-a3c8-4286-af56-e0cf0156f2cd

經測試後

✅ 單曲循環

❌ 全部循環 ➡️ 單曲時，此全部循環 icon 應持續循環，但直接停止；不過專輯時會持續全部循環
->幫改為只有單曲時，就循環那一個單曲

❌ 隨機播放 ➡️ 專輯多曲時，隨機播放 icon，但疑似沒有隨機，播完直接停止，但偶有會有繼續播放； 單曲時，直接停止
https://drive.google.com/file/d/1Cq_PH6m3p0Z3RCRbyy9jic0v7A7y0bu_/view?usp=drive_link

->幫改為只有單曲時，就隨機那一個單曲
->幫檢查專輯多曲時，隨機播放要可以正常運行，協助解決播放完停止的問題
