### PR TITLE
fix: add deleted_at is null in GET_COUPON_COLLECTION & GET_ENROLLED_VOUCHER_COLLECTION

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "libphonenumber-js": "1.9.34",
     "lint-staged": "10.5.4",
     "lodash": "^4.17.15",
-    "lodestar-app-element": "urfit-tech/lodestar-app-element#v.1.53.2",
+    "lodestar-app-element": "urfit-tech/lodestar-app-element#master",
     "moment-timezone": "^0.5.31",
     "mustache": "^4.2.0",
     "organize-imports-cli": "0.7.0",

--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -48,7 +48,7 @@ export const useCouponCollection = (memberId: string) => {
   >(
     gql`
       query GET_COUPON_COLLECTION($memberId: String!) {
-        coupon(where: { member_id: { _eq: $memberId } }) {
+        coupon(where: { member_id: { _eq: $memberId }, coupon_code: { deleted_at: { _is_null: true } } }) {
           id
           status {
             outdated

--- a/src/hooks/voucher.ts
+++ b/src/hooks/voucher.ts
@@ -9,7 +9,10 @@ export const useEnrolledVoucherCollection = (memberId: string) => {
   >(
     gql`
       query GET_ENROLLED_VOUCHER_COLLECTION($memberId: String!) {
-        voucher(where: { member_id: { _eq: $memberId } }, order_by: [{ created_at: desc }]) {
+        voucher(
+          where: { member_id: { _eq: $memberId }, voucher_code: { deleted_at: { _is_null: true } } }
+          order_by: [{ created_at: desc }]
+        ) {
           id
           status {
             outdated

--- a/yarn.lock
+++ b/yarn.lock
@@ -11394,9 +11394,9 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodestar-app-element@urfit-tech/lodestar-app-element#v.1.53.2:
+lodestar-app-element@urfit-tech/lodestar-app-element#master:
   version "0.1.0"
-  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/c7f63f16d473be187941f99a2ca38c031bc947fb"
+  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/fdb2990ecf986b0e96194de4b23575c7a8334ed5"
   dependencies:
     "@apollo/client" "^3.7.11"
     "@bobthered/tailwindcss-palette-generator" "2.0.0"


### PR DESCRIPTION
requirement:

誤發或是需收回權益時可以「註銷」

目前大多情況是使用在退款註銷券、發錯註銷券

且都是隨機碼的情況，比較會有需要註銷券的需求

實作

https://zpl.io/bzgKX13

邏輯如下：

0.請實作於後台折價方案、兌換方案兩個地方

https://demo.lodestar-dev.cc/admin/voucher-plans

https://demo.lodestar-dev.cc/admin/coupon-plans

1.當折價、兌換碼不論為自訂碼或隨機碼時，有出現刪除鈕可以註銷。

2.註銷請做成軟刪除 deleted_at，且不可再被他人使用

3.已被用過的碼，且訂單為「非已完成」（付款中、已完成不可註銷），可以註銷碼。
不管有無被歸戶(歸戶後未使用)，可刪除。

4.按註銷刪除鈕後
若可刪除：會出現系統提示modal，用系統預設的樣式就好
文案：確定要註銷此代碼 CY77-WPDP-B7N 嗎？註銷後將移除此代碼使用權
[取消][確定]

刪除，該碼會直接從後台消失user端也是

若不可刪除：會出現系統提示modal，用系統預設的樣式就好
文案：此代碼 CY77-WPDP-B7N 已被使用，如需註銷請確認該筆訂單狀態為已退款
[確定]