### PR TITLE
Bugfix/modify meeting page and add marketing activities property

### DIFF
--- a/src/pages/MeetingPage/MeetingPage.tsx
+++ b/src/pages/MeetingPage/MeetingPage.tsx
@@ -38,21 +38,28 @@ const MeetingPage = () => {
         .map(value => value.trim())
     : null
 
+  const customMeetingAdProperty =
+    JSON.parse(settings['custom.ad_property.list'] || '{}')?.['meeting']?.['adProperty'] || ''
+  const customMeetingMarketingActivitiesProperty =
+    JSON.parse(settings['custom.ad_property.list'] || '{}')?.['meeting']?.['marketingActivitiesProperty'] || ''
+
   const adPropertyValue = `${
     !adProperty
-      ? 'inbound_英鎊'
-      : adProperty && adProperty.includes('inbound_英鎊')
-      ? adProperty.slice(adProperty.indexOf('inbound_英鎊') - 1, 1).join(',') + ',inbound_英鎊'
-      : adProperty.join(',') + ',inbound_英鎊'
+      ? customMeetingAdProperty
+      : adProperty && adProperty.includes(customMeetingAdProperty)
+      ? [...adProperty.filter(property => property !== customMeetingAdProperty), customMeetingAdProperty].join(',')
+      : `${adProperty.join(',')},${customMeetingAdProperty}`
   }`
 
   const marketingActivitiesPropertyValue = `${
     !marketingActivitiesProperty
-      ? 'inbound_英鎊'
-      : marketingActivitiesProperty && marketingActivitiesProperty.includes('inbound_英鎊')
-      ? marketingActivitiesProperty.slice(marketingActivitiesProperty.indexOf('inbound_英鎊') - 1, 1).join(',') +
-        ',inbound_英鎊'
-      : marketingActivitiesProperty.join(',') + ',inbound_英鎊'
+      ? customMeetingMarketingActivitiesProperty
+      : marketingActivitiesProperty && marketingActivitiesProperty.includes(customMeetingMarketingActivitiesProperty)
+      ? [
+          ...marketingActivitiesProperty.filter(property => property !== customMeetingMarketingActivitiesProperty),
+          customMeetingMarketingActivitiesProperty,
+        ].join(',')
+      : `${marketingActivitiesProperty.join(',')},${customMeetingAdProperty}`
   }`
 
   const [updateMemberCreated] = useMutation<hasura.UPDATE_MEMBER_CREATED, hasura.UPDATE_MEMBER_CREATEDVariables>(

--- a/src/pages/MeetingPage/MeetingPage.tsx
+++ b/src/pages/MeetingPage/MeetingPage.tsx
@@ -67,12 +67,12 @@ const MeetingPage = () => {
       memberPropertiesInput: [
         {
           member_id: currentMemberId,
-          property_id: categoryData?.property.find(({ name }) => name === '廣告素材')!.id,
+          property_id: categoryData?.property.find(({ name }) => name === '廣告素材')?.id,
           value: adPropertyValue,
         },
         {
           member_id: currentMemberId,
-          property_id: categoryData?.property.find(({ name }) => name === '行銷活動')!.id,
+          property_id: categoryData?.property.find(({ name }) => name === '行銷活動')?.id,
           value: marketingActivitiesPropertyValue,
         },
       ],

--- a/src/pages/MeetingPage/MeetingPage.tsx
+++ b/src/pages/MeetingPage/MeetingPage.tsx
@@ -30,6 +30,30 @@ const MeetingPage = () => {
         ?.value.split(',')
         .map(value => value.trim())
     : null
+  // 取得目前登入使用者的行銷活動
+  const marketingActivitiesProperty = memberProperties.find(({ name }) => name === '行銷活動')?.value
+    ? memberProperties
+        .find(({ name }) => name === '行銷活動')
+        ?.value.split(',')
+        .map(value => value.trim())
+    : null
+
+  const adPropertyValue = `${
+    !adProperty
+      ? 'inbound_英鎊'
+      : adProperty && adProperty.includes('inbound_英鎊')
+      ? adProperty.slice(adProperty.indexOf('inbound_英鎊') - 1, 1).join(',') + ',inbound_英鎊'
+      : adProperty.join(',') + ',inbound_英鎊'
+  }`
+
+  const marketingActivitiesPropertyValue = `${
+    !marketingActivitiesProperty
+      ? 'inbound_英鎊'
+      : marketingActivitiesProperty && marketingActivitiesProperty.includes('inbound_英鎊')
+      ? marketingActivitiesProperty.slice(marketingActivitiesProperty.indexOf('inbound_英鎊') - 1, 1).join(',') +
+        ',inbound_英鎊'
+      : marketingActivitiesProperty.join(',') + ',inbound_英鎊'
+  }`
 
   const [updateMemberCreated] = useMutation<hasura.UPDATE_MEMBER_CREATED, hasura.UPDATE_MEMBER_CREATEDVariables>(
     UPDATE_MEMBER_CREATED,
@@ -44,21 +68,16 @@ const MeetingPage = () => {
         {
           member_id: currentMemberId,
           property_id: categoryData?.property.find(({ name }) => name === '廣告素材')!.id,
-          value: `${
-            !adProperty
-              ? 'inbound_英鎊'
-              : adProperty && adProperty.includes('inbound_英鎊')
-              ? [...adProperty.filter(property => property !== 'inbound_英鎊'), 'inbound_英鎊'].join(',')
-              : adProperty.join(',') + ',inbound_英鎊'
-          }`,
+          value: adPropertyValue,
+        },
+        {
+          member_id: currentMemberId,
+          property_id: categoryData?.property.find(({ name }) => name === '行銷活動')!.id,
+          value: marketingActivitiesPropertyValue,
         },
       ],
     },
   })
-
-  const isInsertingAdProperty = JSON.parse(settings['custom.ad_property.list'] || '{}').some(
-    (value: { behavior: string }) => value['behavior'] === 'meeting',
-  )
 
   if (settings['custom.permission_group.salesLead'] !== '1') {
     return <NotFoundPage />
@@ -82,56 +101,61 @@ const MeetingPage = () => {
       utm = {}
     }
 
-    const postAdProperty = [
-      { name: '介紹人', value: referal },
-      { name: '名單分級', value: 'SSR' },
-      { name: '來源網址', value: window.location.href },
-      { name: '聯盟來源', value: utm.utm_source || '' },
-      { name: '聯盟會員編號', value: utm.utm_id || '' },
-      { name: '聯盟成交編號', value: utm.utm_term || '' },
-    ]
-
-    if (isInsertingAdProperty) {
-      postAdProperty.push({ name: '廣告素材', value: 'inbound_英鎊' })
-    }
-
-    if (currentMemberId !== null && isInsertingAdProperty) {
+    if (currentMemberId !== null) {
       updateMemberCreated()
         .then(() => updateMemberProperties())
         .catch(error => {
           console.error('Error during submitting:', error)
         })
-    }
-
-    fetch(process.env.REACT_APP_API_BASE_ROOT + '/sys/create-lead', {
-      method: 'post',
-      body: JSON.stringify({
-        phone,
-        email,
-        name,
-        managerUsername,
-        taskTitle: `專屬預約諮詢:${timeslots.join('/')}`,
-        categoryNames: fields,
-        properties: postAdProperty,
-      }),
-      credentials: 'include',
-      headers: {
-        'Content-Type': 'application/json',
-      },
-    })
-      .then(res => res.json())
-      .then(({ code, message }: { code: string; message: string }) => {
-        if (code === 'SUCCESS') {
+        .finally(() => {
           Cookies.remove('utm')
           alert('已成功預約專屬諮詢！')
-        } else {
-          alert(`發生錯誤，請聯繫 contact@xuemi.co。錯誤訊息：${message}`)
-        }
+          setIsSubmitting(false)
+          window.location.reload()
+        })
+    } else {
+      fetch(process.env.REACT_APP_API_BASE_ROOT + '/sys/create-lead', {
+        method: 'post',
+        body: JSON.stringify({
+          phone,
+          email,
+          name,
+          managerUsername,
+          taskTitle: `專屬預約諮詢:${timeslots.join('/')}`,
+          categoryNames: fields,
+          properties: [
+            { name: '介紹人', value: referal },
+            { name: '名單分級', value: 'SSR' },
+            { name: '來源網址', value: window.location.href },
+            { name: '聯盟來源', value: utm.utm_source || '' },
+            { name: '聯盟會員編號', value: utm.utm_id || '' },
+            { name: '聯盟成交編號', value: utm.utm_term || '' },
+            { name: '廣告素材', value: adPropertyValue },
+            {
+              name: '行銷活動',
+              value: marketingActivitiesPropertyValue,
+            },
+          ],
+        }),
+        credentials: 'include',
+        headers: {
+          'Content-Type': 'application/json',
+        },
       })
-      .finally(() => {
-        setIsSubmitting(false)
-        window.location.reload()
-      })
+        .then(res => res.json())
+        .then(({ code, message }: { code: string; message: string }) => {
+          if (code === 'SUCCESS') {
+            Cookies.remove('utm')
+            alert('已成功預約專屬諮詢！')
+          } else {
+            alert(`發生錯誤，請聯繫網站管理員。錯誤訊息：${message}`)
+          }
+        })
+        .finally(() => {
+          setIsSubmitting(false)
+          window.location.reload()
+        })
+    }
   }
   return (
     <DefaultLayout centeredBox>


### PR DESCRIPTION
requirement:

之前已實作：
登入後填表單，就可以新增此廣告素材
沒有登入的填表單，目前的機制是沒有帳號者，會新增廣告素材

此張需補實作：
沒有登入填表單，有帳號者，也要新增廣告素材

欄位資料會是以,區隔呈現，將資料加入：inbound_英鎊,廣告素材A

-

需求為以下兩種情境下需要掛上inbound：

1.只要是使用 https://www.xuemi.co/meets/us 填單的用戶，不管是自己來填還是透過廣告到學米連到此頁來填寫，都須掛上「inbound_英鎊」掛在自訂欄位的廣告素材

->無限也要做一樣的，無限的網址是https://ooschool.cc/meets/us

2.只要使用「智能測驗」進行註冊者，都須掛上「inbound_英鎊」掛在自訂欄位的廣告素材

https://app.hubspot.com/contacts/20512087/record/0-5/1686437914

-

0810：補一下，除了掛廣告素材之外，【行銷活動】也要同樣自動化掛 inbound_英鎊QQ麻煩連同上一卡任務卡一起補上邏輯（跪