### PR TITLE
feat: add HubSpot chat in MemberPage & ProgramContentPage

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,7 @@
     "hardcopy",
     "hasura",
     "hotjar",
+    "hubspot",
     "ICHEF",
     "ilike",
     "imgs",

--- a/src/pages/MemberPage/index.tsx
+++ b/src/pages/MemberPage/index.tsx
@@ -3,6 +3,7 @@ import { Typography } from 'antd'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import React from 'react'
+import { Helmet } from 'react-helmet'
 import { defineMessages, useIntl } from 'react-intl'
 import { Redirect, useParams } from 'react-router-dom'
 import styled from 'styled-components'
@@ -170,6 +171,17 @@ const MemberPage: React.VFC<{ renderText?: (member: MemberPublicProps) => React.
   )
   return (
     <DefaultLayout>
+      {settings['hubspot.portal_id'] ? (
+        <Helmet>
+          <script
+            type="text/javascript"
+            id="hs-script-loader"
+            async
+            defer
+            src={`//js.hs-scripts.com/${settings['hubspot.portal_id']}.js`}
+          />
+        </Helmet>
+      ) : null}
       {/* // TODO: need to extend page helmet */}
       {!loadingApp && <PageHelmet title={formatMessage(commonMessages.content.myPage)} />}
       <div className=" py-4 py-sm-5" style={{ background: 'white' }}>

--- a/src/pages/ProgramContentPage/index.tsx
+++ b/src/pages/ProgramContentPage/index.tsx
@@ -3,6 +3,7 @@ import { Icon, Layout } from 'antd'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import React, { useState } from 'react'
+import { Helmet } from 'react-helmet'
 import { AiOutlineProfile, AiOutlineUnorderedList } from 'react-icons/ai'
 import { BsStar } from 'react-icons/bs'
 import { defineMessage, useIntl } from 'react-intl'
@@ -63,6 +64,17 @@ const ProgramContentPage: React.VFC = () => {
 
   return (
     <Layout>
+      {settings['hubspot.portal_id'] ? (
+        <Helmet>
+          <script
+            type="text/javascript"
+            id="hs-script-loader"
+            async
+            defer
+            src={`//js.hs-scripts.com/${settings['hubspot.portal_id']}.js`}
+          />
+        </Helmet>
+      ) : null}
       {!loadingApp && <ProgramContentPageHelmet program={program!} contentId={programContentId} />}
       <StyledPageHeader
         title={program?.title || programId}


### PR DESCRIPTION
requirement:

Hubspot chat出現在學米無限我的主頁、學習區的右下角

我們目前是用GTM裝，常被學生說卡卡，使用者體驗不好，KK說要換其他寫法

希望能優先處理

有時第一次進入頁面hubspot那顆不會正常出現，重整才出現

note: sixdigital use core