### PR TITLE
fix: same member appointment

### DIFF
--- a/src/components/appointment/AppointmentItem.tsx
+++ b/src/components/appointment/AppointmentItem.tsx
@@ -45,7 +45,7 @@ const StyledItemMeta = styled.div`
   letter-spacing: 0.34px;
 `
 
-const AppointmentPeriodItem: React.VFC<{
+const AppointmentItem: React.VFC<{
   id: string
   startedAt: Date
   isEnrolled?: boolean
@@ -69,4 +69,4 @@ const AppointmentPeriodItem: React.VFC<{
   )
 }
 
-export default AppointmentPeriodItem
+export default AppointmentItem

--- a/src/components/appointment/AppointmentPeriodCollection.tsx
+++ b/src/components/appointment/AppointmentPeriodCollection.tsx
@@ -51,7 +51,14 @@ const AppointmentPeriodCollection: React.VFC<{
 
           <div className="d-flex flex-wrap justify-content-start">
             {periods.map(period => {
-              const ItemElem = <AppointmentItem key={period.id} id={period.id} startedAt={period.startedAt} />
+              const ItemElem = (
+                <AppointmentItem
+                  key={period.id}
+                  id={period.id}
+                  startedAt={period.startedAt}
+                  isEnrolled={period.currentMemberBooked}
+                />
+              )
 
               return isAuthenticated ? (
                 <div key={period.id} onClick={() => onClick && onClick(period)}>

--- a/src/pages/CreatorPage.tsx
+++ b/src/pages/CreatorPage.tsx
@@ -163,7 +163,11 @@ const CreatorTabs: React.VFC<{
   const { posts } = usePostPreviewCollection({ authorId: creatorId })
   const { enrolledPodcastPlansCreators } = useEnrolledPodcastPlansCreators(currentMemberId || '')
   const { podcastPrograms } = usePodcastProgramCollection(creatorId)
-  const { appointmentPlans } = useAppointmentPlanCollection(creatorId, moment().endOf('minute').toDate())
+  const { appointmentPlans } = useAppointmentPlanCollection(
+    creatorId,
+    moment().endOf('minute').toDate(),
+    currentMemberId || '',
+  )
   const { merchandises } = useMerchandiseCollection({
     isPhysical: isMerchandisesPhysical !== undefined ? !!isMerchandisesPhysical : undefined,
     ownerId: creatorId,

--- a/src/types/appointment.ts
+++ b/src/types/appointment.ts
@@ -21,6 +21,7 @@ export type AppointmentPeriod = {
   startedAt: Date
   endedAt: Date
   booked: number
+  currentMemberBooked: boolean | undefined
   available?: boolean
 }
 


### PR DESCRIPTION
Card:
```
預約方案>>銷售方案>>單場人數上限>>不設限
會員可以重複預約同一天同一時段的諮詢，一個帳號同一時段應該只能預約一次
```
- Additional change: Matching default component name with file naming.