### PR TITLE
feat: add product page's plan list block can fixed

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,7 +94,7 @@
     "libphonenumber-js": "1.9.34",
     "lint-staged": "10.5.4",
     "lodash": "^4.17.15",
-    "lodestar-app-element": "urfit-tech/lodestar-app-element#8f92ccb",
+    "lodestar-app-element": "urfit-tech/lodestar-app-element#master",
     "moment-timezone": "^0.5.31",
     "mustache": "^4.2.0",
     "organize-imports-cli": "0.7.0",

--- a/src/components/project/FundingIntroductionPane.tsx
+++ b/src/components/project/FundingIntroductionPane.tsx
@@ -52,7 +52,7 @@ const FundingIntroductionPane: React.VFC<{
 
   useEffect(() => {
     if (projectPlans) {
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
     }
   }, [projectPlans])
 

--- a/src/components/project/FundingIntroductionPane.tsx
+++ b/src/components/project/FundingIntroductionPane.tsx
@@ -52,7 +52,7 @@ const FundingIntroductionPane: React.VFC<{
 
   useEffect(() => {
     if (projectPlans) {
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 110)
     }
   }, [projectPlans])
 
@@ -72,7 +72,7 @@ const FundingIntroductionPane: React.VFC<{
         </TabPaneContent>
 
         <div className="col-12 col-lg-4">
-          <div className={`${isPlanListSticky ? 'positionSticky' : ''}`} ref={planListHeightRef}>
+          <div className={`${isPlanListSticky ? 'projectPlanSticky' : ''}`} ref={planListHeightRef}>
             <ProjectPlanCollection projectPlans={projectPlans} />
           </div>
         </div>

--- a/src/components/project/FundingIntroductionPane.tsx
+++ b/src/components/project/FundingIntroductionPane.tsx
@@ -1,6 +1,6 @@
 import { Button } from 'antd'
 import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
-import React, { useState } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import styled, { css } from 'styled-components'
 import { commonMessages } from '../../helpers/translation'
@@ -47,6 +47,14 @@ const FundingIntroductionPane: React.VFC<{
 }> = ({ introduction, projectPlans }) => {
   const [collapsed, setCollapsed] = useState(false)
   const { formatMessage } = useIntl()
+  const [isPlanListSticky, setIsPlanListSticky] = useState(false)
+  const planListHeightRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (projectPlans) {
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
+    }
+  }, [projectPlans])
 
   return (
     <div className="container">
@@ -64,7 +72,7 @@ const FundingIntroductionPane: React.VFC<{
         </TabPaneContent>
 
         <div className="col-12 col-lg-4">
-          <div className="positionSticky">
+          <div className={`${isPlanListSticky ? 'positionSticky' : ''}`} ref={planListHeightRef}>
             <ProjectPlanCollection projectPlans={projectPlans} />
           </div>
         </div>

--- a/src/components/project/FundingIntroductionPane.tsx
+++ b/src/components/project/FundingIntroductionPane.tsx
@@ -1,11 +1,11 @@
 import { Button } from 'antd'
+import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
 import React, { useState } from 'react'
 import { useIntl } from 'react-intl'
 import styled, { css } from 'styled-components'
 import { commonMessages } from '../../helpers/translation'
 import { ProjectPlanProps } from '../../types/project'
 import Responsive, { BREAK_POINT } from '../common/Responsive'
-import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
 import ProjectPlanCollection from './ProjectPlanCollection'
 
 const TabPaneContent = styled.div<{ collapsed?: boolean }>`
@@ -50,8 +50,8 @@ const FundingIntroductionPane: React.VFC<{
 
   return (
     <div className="container">
-      <div className="row">
-        <TabPaneContent className="col-12 col-lg-8 mb-5" collapsed={collapsed}>
+      <div className="row mb-5">
+        <TabPaneContent className="col-12 col-lg-8" collapsed={collapsed}>
           {<BraftContent>{introduction}</BraftContent>}
 
           {collapsed && (
@@ -63,8 +63,10 @@ const FundingIntroductionPane: React.VFC<{
           )}
         </TabPaneContent>
 
-        <div className="col-12 col-lg-4 mb-5">
-          <ProjectPlanCollection projectPlans={projectPlans} />
+        <div className="col-12 col-lg-4">
+          <div className="positionSticky">
+            <ProjectPlanCollection projectPlans={projectPlans} />
+          </div>
         </div>
       </div>
     </div>

--- a/src/pages/ActivityPage/ActivityPage.tsx
+++ b/src/pages/ActivityPage/ActivityPage.tsx
@@ -4,7 +4,7 @@ import Tracking from 'lodestar-app-element/src/components/common/Tracking'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { useResourceCollection } from 'lodestar-app-element/src/hooks/resource'
-import React, { useEffect } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import { Col, Container, Row } from 'react-bootstrap'
 import ReactGA from 'react-ga'
 import { useIntl } from 'react-intl'
@@ -53,6 +53,8 @@ const ActivityPage: React.VFC = () => {
   const { id: appId } = useApp()
   const { resourceCollection } = useResourceCollection([`${appId}:activity:${activityId}`], true)
   const { loading, error, activity } = useActivity({ activityId, memberId: currentMemberId || '' })
+  const [isPlanListSticky, setIsPlanListSticky] = useState(false)
+  const planListHeightRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (activity) {
@@ -77,6 +79,7 @@ const ActivityPage: React.VFC = () => {
         ReactGA.plugin.execute('ec', 'setAction', 'detail')
       }
       ReactGA.ga('send', 'pageview')
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
     }
   }, [activity])
 
@@ -119,7 +122,7 @@ const ActivityPage: React.VFC = () => {
           </Col>
 
           <Col xs={12} lg={4}>
-            <div className="positionSticky">
+            <div className={`${isPlanListSticky ? 'positionSticky' : ''}`} ref={planListHeightRef}>
               <AuthModalContext.Consumer>
                 {({ setVisible: setAuthModalVisible }) =>
                   activity.tickets.map(ticket => {

--- a/src/pages/ActivityPage/ActivityPage.tsx
+++ b/src/pages/ActivityPage/ActivityPage.tsx
@@ -1,4 +1,5 @@
 import { Button, Divider, SkeletonText } from '@chakra-ui/react'
+import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
 import Tracking from 'lodestar-app-element/src/components/common/Tracking'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
@@ -16,13 +17,12 @@ import ActivityTicketPaymentButton from '../../components/activity/ActivityTicke
 import { AuthModalContext } from '../../components/auth/AuthModal'
 import CreatorCard from '../../components/common/CreatorCard'
 import { BREAK_POINT } from '../../components/common/Responsive'
-import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
 import DefaultLayout from '../../components/layout/DefaultLayout'
 import { commonMessages, productMessages } from '../../helpers/translation'
 import { useActivity } from '../../hooks/activity'
 import { usePublicMember } from '../../hooks/member'
-import ActivityPageHelmet from './ActivityPageHelmet'
 import NotFoundPage from '../NotFoundPage'
+import ActivityPageHelmet from './ActivityPageHelmet'
 
 const ActivityContent = styled(Container)`
   && {
@@ -119,78 +119,80 @@ const ActivityPage: React.VFC = () => {
           </Col>
 
           <Col xs={12} lg={4}>
-            <AuthModalContext.Consumer>
-              {({ setVisible: setAuthModalVisible }) =>
-                activity.tickets.map(ticket => {
-                  return (
-                    <div key={ticket.id} className="mb-4">
-                      <ActivityTicketCard
-                        title={ticket.title}
-                        description={ticket.description || undefined}
-                        price={ticket.price}
-                        count={ticket.count}
-                        startedAt={ticket.startedAt}
-                        endedAt={ticket.endedAt}
-                        isPublished={ticket.isPublished}
-                        sessions={activity.ticketSessions
-                          .filter(ticketSession => ticketSession.ticket.id === ticket.id)
-                          .map(ticketSession => ({
-                            id: ticketSession.session.id,
-                            type: ticketSession.session.type,
-                            title: ticketSession.session.title,
-                          }))}
-                        participants={ticket.participants}
-                        currencyId={ticket.currencyId}
-                        extra={
-                          !activity ||
-                          !activity.publishedAt ||
-                          activity.publishedAt.getTime() > Date.now() ||
-                          ticket.startedAt.getTime() > Date.now() ? (
-                            <Button isFullWidth isDisabled>
-                              {formatMessage(commonMessages.button.unreleased)}
-                            </Button>
-                          ) : ticket.enrollments.length > 0 ? (
-                            <Button
-                              variant="outline"
-                              isFullWidth
-                              onClick={() =>
-                                history.push(
-                                  `/orders/${ticket.enrollments[0].orderId}/products/${ticket.enrollments[0].orderProductId}`,
-                                )
-                              }
-                            >
-                              {formatMessage(commonMessages.button.ticket)}
-                            </Button>
-                          ) : ticket.participants >= ticket.count ? (
-                            <Button isFullWidth isDisabled>
-                              {formatMessage(commonMessages.button.soldOut)}
-                            </Button>
-                          ) : ticket.endedAt.getTime() < Date.now() ? (
-                            <Button isFullWidth isDisabled>
-                              {formatMessage(commonMessages.button.cutoff)}
-                            </Button>
-                          ) : isAuthenticated ? (
-                            <ActivityTicketPaymentButton
-                              ticketId={ticket.id}
-                              ticketPrice={ticket.price}
-                              ticketCurrencyId={ticket.currencyId}
-                            />
-                          ) : (
-                            <Button
-                              colorScheme="primary"
-                              isFullWidth
-                              onClick={() => setAuthModalVisible && setAuthModalVisible(true)}
-                            >
-                              {formatMessage(commonMessages.button.register)}
-                            </Button>
-                          )
-                        }
-                      />
-                    </div>
-                  )
-                })
-              }
-            </AuthModalContext.Consumer>
+            <div className="positionSticky">
+              <AuthModalContext.Consumer>
+                {({ setVisible: setAuthModalVisible }) =>
+                  activity.tickets.map(ticket => {
+                    return (
+                      <div key={ticket.id} className="mb-4">
+                        <ActivityTicketCard
+                          title={ticket.title}
+                          description={ticket.description || undefined}
+                          price={ticket.price}
+                          count={ticket.count}
+                          startedAt={ticket.startedAt}
+                          endedAt={ticket.endedAt}
+                          isPublished={ticket.isPublished}
+                          sessions={activity.ticketSessions
+                            .filter(ticketSession => ticketSession.ticket.id === ticket.id)
+                            .map(ticketSession => ({
+                              id: ticketSession.session.id,
+                              type: ticketSession.session.type,
+                              title: ticketSession.session.title,
+                            }))}
+                          participants={ticket.participants}
+                          currencyId={ticket.currencyId}
+                          extra={
+                            !activity ||
+                            !activity.publishedAt ||
+                            activity.publishedAt.getTime() > Date.now() ||
+                            ticket.startedAt.getTime() > Date.now() ? (
+                              <Button isFullWidth isDisabled>
+                                {formatMessage(commonMessages.button.unreleased)}
+                              </Button>
+                            ) : ticket.enrollments.length > 0 ? (
+                              <Button
+                                variant="outline"
+                                isFullWidth
+                                onClick={() =>
+                                  history.push(
+                                    `/orders/${ticket.enrollments[0].orderId}/products/${ticket.enrollments[0].orderProductId}`,
+                                  )
+                                }
+                              >
+                                {formatMessage(commonMessages.button.ticket)}
+                              </Button>
+                            ) : ticket.participants >= ticket.count ? (
+                              <Button isFullWidth isDisabled>
+                                {formatMessage(commonMessages.button.soldOut)}
+                              </Button>
+                            ) : ticket.endedAt.getTime() < Date.now() ? (
+                              <Button isFullWidth isDisabled>
+                                {formatMessage(commonMessages.button.cutoff)}
+                              </Button>
+                            ) : isAuthenticated ? (
+                              <ActivityTicketPaymentButton
+                                ticketId={ticket.id}
+                                ticketPrice={ticket.price}
+                                ticketCurrencyId={ticket.currencyId}
+                              />
+                            ) : (
+                              <Button
+                                colorScheme="primary"
+                                isFullWidth
+                                onClick={() => setAuthModalVisible && setAuthModalVisible(true)}
+                              >
+                                {formatMessage(commonMessages.button.register)}
+                              </Button>
+                            )
+                          }
+                        />
+                      </div>
+                    )
+                  })
+                }
+              </AuthModalContext.Consumer>
+            </div>
           </Col>
         </Row>
 

--- a/src/pages/ActivityPage/ActivityPage.tsx
+++ b/src/pages/ActivityPage/ActivityPage.tsx
@@ -79,7 +79,7 @@ const ActivityPage: React.VFC = () => {
         ReactGA.plugin.execute('ec', 'setAction', 'detail')
       }
       ReactGA.ga('send', 'pageview')
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
     }
   }, [activity])
 

--- a/src/pages/ActivityPage/ActivityPage.tsx
+++ b/src/pages/ActivityPage/ActivityPage.tsx
@@ -79,7 +79,7 @@ const ActivityPage: React.VFC = () => {
         ReactGA.plugin.execute('ec', 'setAction', 'detail')
       }
       ReactGA.ga('send', 'pageview')
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 56)
     }
   }, [activity])
 
@@ -122,7 +122,7 @@ const ActivityPage: React.VFC = () => {
           </Col>
 
           <Col xs={12} lg={4}>
-            <div className={`${isPlanListSticky ? 'positionSticky' : ''}`} ref={planListHeightRef}>
+            <div className={`${isPlanListSticky ? 'activityPlanSticky' : ''}`} ref={planListHeightRef}>
               <AuthModalContext.Consumer>
                 {({ setVisible: setAuthModalVisible }) =>
                   activity.tickets.map(ticket => {

--- a/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
+++ b/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
@@ -5,7 +5,7 @@ import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { useResourceCollection } from 'lodestar-app-element/src/hooks/resource'
 import { useTracking } from 'lodestar-app-element/src/hooks/tracking'
-import React, { createRef, useEffect } from 'react'
+import React, { useEffect, useRef, useState } from 'react'
 import ReactGA from 'react-ga'
 import { defineMessages, useIntl } from 'react-intl'
 import { Link, useParams } from 'react-router-dom'
@@ -75,8 +75,9 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
   const { loadingProgramPackageIds, enrolledProgramPackagePlanIds } = useEnrolledProgramPackagePlanIds(
     currentMemberId || '',
   )
-
-  const planBlockRef = createRef<HTMLDivElement>()
+  const [isPlanListSticky, setIsPlanListSticky] = useState(false)
+  const planBlockRef = useRef<HTMLDivElement>(null)
+  const planListHeightRef = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
     if (programPackageIntroduction) {
@@ -99,6 +100,7 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
       })
       ReactGA.plugin.execute('ec', 'setAction', 'detail')
       ReactGA.ga('send', 'pageview')
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
     }
   }, [programPackageIntroduction])
 
@@ -157,7 +159,7 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
                 />
               </div>
               <div ref={planBlockRef} className="col-12 col-lg-4 pt-5">
-                <div className="positionSticky">
+                <div ref={planListHeightRef} className={`${isPlanListSticky ? 'positionSticky' : ''}`}>
                   {programPackageIntroduction.plans.map(programPackagePlan => (
                     <div key={programPackagePlan.id} className="mb-4">
                       <ProgramPackagePlanCard

--- a/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
+++ b/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
@@ -100,7 +100,7 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
       })
       ReactGA.plugin.execute('ec', 'setAction', 'detail')
       ReactGA.ga('send', 'pageview')
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 40)
     }
   }, [programPackageIntroduction])
 
@@ -159,7 +159,7 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
                 />
               </div>
               <div ref={planBlockRef} className="col-12 col-lg-4 pt-5">
-                <div ref={planListHeightRef} className={`${isPlanListSticky ? 'positionSticky' : ''}`}>
+                <div ref={planListHeightRef} className={`${isPlanListSticky ? 'programPackagePlanSticky' : ''}`}>
                   {programPackageIntroduction.plans.map(programPackagePlan => (
                     <div key={programPackagePlan.id} className="mb-4">
                       <ProgramPackagePlanCard

--- a/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
+++ b/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
@@ -1,14 +1,16 @@
 import { Button } from '@chakra-ui/react'
 import { CommonLargeTitleMixin } from 'lodestar-app-element/src/components/common'
+import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { useResourceCollection } from 'lodestar-app-element/src/hooks/resource'
+import { useTracking } from 'lodestar-app-element/src/hooks/tracking'
 import React, { createRef, useEffect } from 'react'
 import ReactGA from 'react-ga'
 import { defineMessages, useIntl } from 'react-intl'
 import { Link, useParams } from 'react-router-dom'
 import styled, { css } from 'styled-components'
-import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
+import { StringParam, useQueryParam } from 'use-query-params'
 import DefaultLayout from '../../components/layout/DefaultLayout'
 import ProgramCollection from '../../components/package/ProgramCollection'
 import ProgramPackageBanner from '../../components/package/ProgramPackageBanner'
@@ -19,8 +21,6 @@ import { desktopViewMixin } from '../../helpers'
 import { commonMessages } from '../../helpers/translation'
 import { useEnrolledProgramPackagePlanIds, useProgramPackageIntroduction } from '../../hooks/programPackage'
 import NotFoundPage from '../NotFoundPage'
-import { useTracking } from 'lodestar-app-element/src/hooks/tracking'
-import { StringParam, useQueryParam } from 'use-query-params'
 
 const StyledTitle = styled.h2`
   ${CommonLargeTitleMixin}
@@ -157,16 +157,18 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
                 />
               </div>
               <div ref={planBlockRef} className="col-12 col-lg-4 pt-5">
-                {programPackageIntroduction.plans.map(programPackagePlan => (
-                  <div key={programPackagePlan.id} className="mb-4">
-                    <ProgramPackagePlanCard
-                      programPackageId={programPackageId}
-                      {...programPackagePlan}
-                      loading={loadingProgramPackageIds}
-                      isEnrolled={enrolledProgramPackagePlanIds.includes(programPackagePlan.id)}
-                    />
-                  </div>
-                ))}
+                <div className="positionSticky">
+                  {programPackageIntroduction.plans.map(programPackagePlan => (
+                    <div key={programPackagePlan.id} className="mb-4">
+                      <ProgramPackagePlanCard
+                        programPackageId={programPackageId}
+                        {...programPackagePlan}
+                        loading={loadingProgramPackageIds}
+                        isEnrolled={enrolledProgramPackagePlanIds.includes(programPackagePlan.id)}
+                      />
+                    </div>
+                  ))}
+                </div>
               </div>
             </>
           ) : (

--- a/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
+++ b/src/pages/ProgramPackagePage/ProgramPackagePage.tsx
@@ -100,7 +100,7 @@ const ProgramPackagePageContent: React.VFC<{ programPackageId: string }> = ({ pr
       })
       ReactGA.plugin.execute('ec', 'setAction', 'detail')
       ReactGA.ga('send', 'pageview')
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
     }
   }, [programPackageIntroduction])
 

--- a/src/pages/ProgramPage/index.tsx
+++ b/src/pages/ProgramPage/index.tsx
@@ -146,7 +146,7 @@ const ProgramPageContent: React.VFC = () => {
 
   useEffect(() => {
     if (!loadingProgramPlansEnrollmentsAggregateList) {
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
     }
   }, [loadingProgramPlansEnrollmentsAggregateList])
 

--- a/src/pages/ProgramPage/index.tsx
+++ b/src/pages/ProgramPage/index.tsx
@@ -115,9 +115,11 @@ const ProgramPageContent: React.VFC = () => {
   const { loading: loadingEnrolledProgramIds, enrolledProgramIds } = useEnrolledProgramIds(currentMemberId || '')
   const { loading: loadingProgramPlansEnrollmentsAggregateList, programPlansEnrollmentsAggregateList } =
     useProgramPlansEnrollmentsAggregateList(program?.plans.map(plan => plan.id) || [])
+  const [isPlanListSticky, setIsPlanListSticky] = useState(false)
 
   const planBlockRef = useRef<HTMLDivElement | null>(null)
   const customerReviewBlockRef = useRef<HTMLDivElement>(null)
+  const planListHeightRef = useRef<HTMLDivElement>(null)
 
   const isEnrolled = enrolledProgramIds.includes(programId)
 
@@ -141,6 +143,12 @@ const ProgramPageContent: React.VFC = () => {
   useEffect(() => {
     ReactGA.ga('send', 'pageview')
   }, [])
+
+  useEffect(() => {
+    if (!loadingProgramPlansEnrollmentsAggregateList) {
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 100)
+    }
+  }, [loadingProgramPlansEnrollmentsAggregateList])
 
   if (!loadingEnrolledProgramIds && !visitIntro && isEnrolled) {
     return <Redirect to={`/programs/${programId}/contents?back=${previousPage || `programs_${programId}`}`} />
@@ -258,7 +266,11 @@ const ProgramPageContent: React.VFC = () => {
                   </Responsive.Desktop>
 
                   {!isEnrolledByProgramPackage && programPlansEnrollmentsAggregateList && (
-                    <div id="subscription" className="mb-5 positionSticky">
+                    <div
+                      id="subscription"
+                      className={`mb-5${isPlanListSticky ? ' positionSticky' : ''}`}
+                      ref={planListHeightRef}
+                    >
                       {program.plans
                         .filter(programPlan => programPlan.publishedAt)
                         .map(programPlan => (

--- a/src/pages/ProgramPage/index.tsx
+++ b/src/pages/ProgramPage/index.tsx
@@ -253,33 +253,28 @@ const ProgramPageContent: React.VFC = () => {
                 </Responsive.Desktop>
               ) : (
                 <StyledIntroWrapper ref={planBlockRef} className="col-12 col-lg-4">
-                  <div>
-                    <Responsive.Desktop>
-                      <ProgramInfoCard instructorId={instructorId} program={program} />
-                    </Responsive.Desktop>
+                  <Responsive.Desktop>
+                    <ProgramInfoCard instructorId={instructorId} program={program} />
+                  </Responsive.Desktop>
 
-                    {!isEnrolledByProgramPackage && programPlansEnrollmentsAggregateList && (
-                      <div className="mb-5">
-                        <div id="subscription">
-                          {program.plans
-                            .filter(programPlan => programPlan.publishedAt)
-                            .map(programPlan => (
-                              <div key={programPlan.id} className="mb-3">
-                                <ProgramPlanCard
-                                  programId={program.id}
-                                  programPlan={programPlan}
-                                  enrollmentCount={
-                                    programPlansEnrollmentsAggregateList.find(v => v.id === programPlan.id)
-                                      ?.enrollmentCount
-                                  }
-                                  isProgramSoldOut={Boolean(program.isSoldOut)}
-                                />
-                              </div>
-                            ))}
-                        </div>
-                      </div>
-                    )}
-                  </div>
+                  {!isEnrolledByProgramPackage && programPlansEnrollmentsAggregateList && (
+                    <div id="subscription" className="mb-5 positionSticky">
+                      {program.plans
+                        .filter(programPlan => programPlan.publishedAt)
+                        .map(programPlan => (
+                          <div key={programPlan.id} className="mb-3">
+                            <ProgramPlanCard
+                              programId={program.id}
+                              programPlan={programPlan}
+                              enrollmentCount={
+                                programPlansEnrollmentsAggregateList.find(v => v.id === programPlan.id)?.enrollmentCount
+                              }
+                              isProgramSoldOut={Boolean(program.isSoldOut)}
+                            />
+                          </div>
+                        ))}
+                    </div>
+                  )}
                 </StyledIntroWrapper>
               )}
             </div>

--- a/src/pages/ProgramPage/index.tsx
+++ b/src/pages/ProgramPage/index.tsx
@@ -146,7 +146,7 @@ const ProgramPageContent: React.VFC = () => {
 
   useEffect(() => {
     if (!loadingProgramPlansEnrollmentsAggregateList) {
-      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 104)
+      setIsPlanListSticky(window.innerHeight > (planListHeightRef.current?.clientHeight || 0) + 40)
     }
   }, [loadingProgramPlansEnrollmentsAggregateList])
 
@@ -268,7 +268,7 @@ const ProgramPageContent: React.VFC = () => {
                   {!isEnrolledByProgramPackage && programPlansEnrollmentsAggregateList && (
                     <div
                       id="subscription"
-                      className={`mb-5${isPlanListSticky ? ' positionSticky' : ''}`}
+                      className={`mb-5${isPlanListSticky ? ' programPlanSticky' : ''}`}
                       ref={planListHeightRef}
                     >
                       {program.plans

--- a/src/pages/ProjectPage/FundingPage.tsx
+++ b/src/pages/ProjectPage/FundingPage.tsx
@@ -21,6 +21,7 @@ const StyledCover = styled.div`
   padding-top: 2.5rem;
 `
 const StyledTabs = styled(Tabs)`
+  overflow: unset;
   .ant-tabs-bar {
     display: flex;
     justify-content: space-between;

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -89,7 +89,23 @@
   bottom: 100px !important;
 }
 
-.positionSticky {
+.programPlanSticky {
   position: sticky;
   top: 40px;
 }
+
+.programPackagePlanSticky {
+  position: sticky;
+  top: 48px;
+}
+
+.projectPlanSticky {
+  position: sticky;
+  top: 110px;
+}
+
+.activityPlanSticky {
+  position: sticky;
+  top: 56px;
+}
+

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -88,3 +88,8 @@
 .fb_customer_chat_bubble_pop_in {
   bottom: 100px !important;
 }
+
+.positionSticky {
+  position: sticky;
+  top: 100px;
+}

--- a/src/styles.scss
+++ b/src/styles.scss
@@ -91,5 +91,5 @@
 
 .positionSticky {
   position: sticky;
-  top: 100px;
+  top: 40px;
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -11399,9 +11399,9 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-lodestar-app-element@urfit-tech/lodestar-app-element#8f92ccb:
+lodestar-app-element@urfit-tech/lodestar-app-element#master:
   version "0.1.0"
-  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/8f92ccbacca4b6b70a753ef0f62cdaa508e9ac8f"
+  resolved "https://codeload.github.com/urfit-tech/lodestar-app-element/tar.gz/e60c2bfa0a5e4ec0252d954ac8d64de6148a3e08"
   dependencies:
     "@apollo/client" "^3.7.11"
     "@bobthered/tailwindcss-palette-generator" "2.0.0"


### PR DESCRIPTION
## 需求

- 請調整為 會不會爆版 為判斷，而不以類型區分

  - 在沒有爆版的情況下，方案區塊的操作如
  
  - 在爆版的情況下，方案區塊的操作如目前課程一樣，卡片無需固定https://www.cwlearning.com.tw/programs/d4427286-6739-4953-b56d-8b2ace59024b?visitIntro=1

- 註：爆版的定義為超出螢幕畫面中可呈現的範圍

- 需實作在課程簡介、課程組合、專案、活動

- 留意天下課程簡介有魔改，他要適用之外其他標準客戶也須適用此邏輯



ZZ留存：https://docs.google.com/document/d/14pZj5FxEISPqfzvYwPnn2LWxOHMWNb4_NH4dxDwXFso/edit

## 實作

調整「課程頁」、「課程組合頁」、「專案頁」和「活動頁」結構

並在各個產品的方案區塊加上「positionSticky」的 className

用於滾動後固定住產品方案列