### PR TITLE
fix: isEnrolled AppointmentItem onClick

### DIFF
--- a/src/components/appointment/AppointmentPeriodCollection.tsx
+++ b/src/components/appointment/AppointmentPeriodCollection.tsx
@@ -60,8 +60,17 @@ const AppointmentPeriodCollection: React.VFC<{
                 />
               )
 
-              return isAuthenticated ? (
+              return isAuthenticated && !period.currentMemberBooked ? (
                 <div key={period.id} onClick={() => onClick && onClick(period)}>
+                  {ItemElem}
+                </div>
+              ) : isAuthenticated && period.currentMemberBooked ? (
+                <div
+                  key={period.id}
+                  onClick={() => {
+                    return
+                  }}
+                >
                   {ItemElem}
                 </div>
               ) : (


### PR DESCRIPTION
Issues:
When `period.currentMemberBooked` is true for the AppointmentItem, the style is displayed in a disabled state, but the appointment modal can still be opened by clicking.

Reason:
The component requires an additional wrapping `<div>` layer and the use of onClick return to effectively disable it.

Adjustment:
As mentioned above, the adjustment adds an additional wrapping `<div>` to the component and utilizes onClick return to achieve the desired disabling effect effectively.

Card message :
```
只有畫面看起來「已預約」
實際上卻還是可以點擊….
要disabled才對
```