### PR TITLE
refactor: voucher hook to use axios

### DIFF
--- a/src/components/voucher/VoucherCollectionBlock.tsx
+++ b/src/components/voucher/VoucherCollectionBlock.tsx
@@ -30,8 +30,8 @@ const VoucherCollectionBlock: React.VFC = () => {
   const {
     loading: loadingEnrolledVoucherCollection,
     error: errorEnrolledVoucherCollection,
-    enrolledVoucherCollection,
-    refetch: refetchEnrolledVoucherCollection,
+    data: enrolledVoucherCollection,
+    fetch: refetchEnrolledVoucherCollection,
   } = useEnrolledVoucherCollection(currentMemberId || '')
 
   const handleRefetch = () => {

--- a/src/hooks/voucher.ts
+++ b/src/hooks/voucher.ts
@@ -1,79 +1,63 @@
-import { gql, NetworkStatus, useQuery } from '@apollo/client'
+import axios from 'axios'
+import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
+import { useCallback, useEffect, useState } from 'react'
 import { VoucherProps } from '../components/voucher/Voucher'
-import hasura from '../hasura'
 
 export const useEnrolledVoucherCollection = (memberId: string) => {
-  const { loading, error, data, refetch, networkStatus } = useQuery<
-    hasura.GET_ENROLLED_VOUCHER_COLLECTION,
-    hasura.GET_ENROLLED_VOUCHER_COLLECTIONVariables
-  >(
-    gql`
-      query GET_ENROLLED_VOUCHER_COLLECTION($memberId: String!) {
-        voucher(
-          where: { member_id: { _eq: $memberId }, voucher_code: { deleted_at: { _is_null: true } } }
-          order_by: [{ created_at: desc }]
-        ) {
-          id
-          status {
-            outdated
-            used
-          }
-          voucher_code {
-            id
-            code
-            voucher_plan {
-              id
-              title
-              description
-              started_at
-              ended_at
-              is_transferable
-              product_quantity_limit
-              voucher_plan_products {
-                id
-                product_id
-              }
-            }
-          }
-        }
-      }
-    `,
-    {
-      variables: { memberId },
-      notifyOnNetworkStatusChange: true,
-    },
-  )
+  const { authToken } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<any>()
+  const [data, setData] = useState<
+    (VoucherProps & {
+      productIds: string[]
+      voucherPlanId: string
+    })[]
+  >([])
 
-  const enrolledVoucherCollection: (VoucherProps & {
-    productIds: string[]
-    voucherPlanId: string
-  })[] =
-    data?.voucher.map(voucher => ({
-      id: voucher.id,
-      title: voucher.voucher_code.voucher_plan.title,
-      startedAt: voucher.voucher_code.voucher_plan.started_at
-        ? new Date(voucher.voucher_code.voucher_plan.started_at)
-        : undefined,
-      endedAt: voucher.voucher_code.voucher_plan.ended_at
-        ? new Date(voucher.voucher_code.voucher_plan.ended_at)
-        : undefined,
-      productQuantityLimit: voucher.voucher_code.voucher_plan.product_quantity_limit,
-      available: !!voucher.status && !voucher.status.outdated && !voucher.status.used,
-      productIds: voucher.voucher_code.voucher_plan.voucher_plan_products.map(product => product.product_id),
-      description: decodeURI(voucher.voucher_code.voucher_plan.description || ''),
-      isTransferable: voucher.voucher_code.voucher_plan.is_transferable,
-      voucherCode: {
-        id: voucher.voucher_code.id,
-        code: voucher.voucher_code.code,
-      },
-      status: { outdated: voucher.status?.outdated, used: voucher.status?.used },
-      voucherPlanId: voucher.voucher_code.voucher_plan.id,
-    })) || []
+  const fetch = useCallback(async () => {
+    if (authToken) {
+      try {
+        setLoading(true)
+        const { data } = await axios.get(
+          `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/vouchers${memberId ? `/?memberId=${memberId}` : ''}`,
+          {
+            headers: { authorization: `Bearer ${authToken}` },
+          },
+        )
+        setData(
+          data.map(
+            (
+              voucher: VoucherProps & {
+                voucherPlanProducts: { id: string; productId: string }[]
+                voucherPlanId: string
+              },
+            ) => ({
+              ...voucher,
+              startedAt: voucher.startedAt ? new Date(voucher.startedAt) : undefined,
+              endedAt: voucher.endedAt ? new Date(voucher.endedAt) : undefined,
+              description: decodeURI(voucher.description || ''),
+              available: !!voucher.status && !voucher.status.outdated && !voucher.status.used,
+              productIds: voucher.voucherPlanProducts.map(product => product.productId),
+            }),
+          ) || [],
+        )
+      } catch (err) {
+        console.log(err)
+        setError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+  }, [authToken])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
 
   return {
-    loading: loading || networkStatus === NetworkStatus.refetch,
+    loading,
     error,
-    enrolledVoucherCollection,
-    refetch,
+    data,
+    fetch,
   }
 }


### PR DESCRIPTION
Replaced GraphQL queries in the `useEnrolledVoucherCollection` hook with axios calls and context-based authentication to improve reliability. Data fetching is now more efficient and aligned with the new authorization standards. Additionally, replaced the `useQuery` hook with custom state management and fetch function to better handle loading and error states. This change streamlines the process of fetching enrolled vouchers by utilizing the RESTful endpoint and managing state explicitly within the hook.