### PR TITLE
refactor: coupon fetching to use external API

### DIFF
--- a/src/hooks/data.ts
+++ b/src/hooks/data.ts
@@ -1,8 +1,9 @@
 import { gql, useMutation, useQuery } from '@apollo/client'
+import axios from 'axios'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { sum } from 'ramda'
-import { useContext } from 'react'
+import { useCallback, useContext, useEffect, useState } from 'react'
 import { useLocation } from 'react-router-dom'
 import { v4 as uuid } from 'uuid'
 import LocaleContext from '../contexts/LocaleContext'
@@ -10,6 +11,7 @@ import { GET_NOTIFICATIONS, NotificationProps } from '../contexts/NotificationCo
 import hasura from '../hasura'
 import { handleError, uploadFile } from '../helpers/index'
 import { CouponProps } from '../types/checkout'
+import { CouponFromLodestarAPI } from '../types/coupon'
 
 export const useNotifications = (limit: number) => {
   const { loading, error, data, refetch } = useQuery<hasura.GET_NOTIFICATIONS, hasura.GET_NOTIFICATIONSVariables>(
@@ -41,86 +43,63 @@ export const useNotifications = (limit: number) => {
 }
 
 export const useCouponCollection = (memberId: string) => {
-  const { loading, error, data, refetch } = useQuery<
-    hasura.GET_COUPON_COLLECTION,
-    hasura.GET_COUPON_COLLECTIONVariables
-  >(
-    gql`
-      query GET_COUPON_COLLECTION($memberId: String!) {
-        coupon(where: { member_id: { _eq: $memberId }, coupon_code: { deleted_at: { _is_null: true } } }) {
-          id
-          status {
-            outdated
-            used
-          }
-          coupon_code {
-            code
-            coupon_plan {
-              id
-              title
-              amount
-              type
-              constraint
-              started_at
-              ended_at
-              description
-              scope
-              coupon_plan_products {
-                id
-                product_id
-              }
-            }
-          }
-        }
-      }
-    `,
-    { variables: { memberId } },
-  )
+  const { authToken } = useAuth()
+  const [loading, setLoading] = useState(false)
+  const [error, setError] = useState<any>()
+  const [data, setData] = useState<CouponProps[]>([])
 
-  const coupons: CouponProps[] =
-    loading || error || !data
-      ? []
-      : data.coupon.map(coupon => ({
-          id: coupon.id,
-          status: {
-            used: coupon.status?.used || false,
-            outdated: coupon.status?.outdated || false,
-          },
-          couponCode: {
-            code: coupon.coupon_code.code,
-            couponPlan: {
-              id: coupon.coupon_code.coupon_plan.id,
-              startedAt: coupon.coupon_code.coupon_plan.started_at
-                ? new Date(coupon.coupon_code.coupon_plan.started_at)
-                : null,
-              endedAt: coupon.coupon_code.coupon_plan.ended_at
-                ? new Date(coupon.coupon_code.coupon_plan.ended_at)
-                : null,
-              type:
-                coupon.coupon_code.coupon_plan.type === 1
-                  ? 'cash'
-                  : coupon.coupon_code.coupon_plan.type === 2
-                  ? 'percent'
-                  : 'cash',
-              constraint: coupon.coupon_code.coupon_plan.constraint,
-              amount: coupon.coupon_code.coupon_plan.amount,
-              title: coupon.coupon_code.coupon_plan.title,
-              description: coupon.coupon_code.coupon_plan.description || '',
-              count: 0,
-              remaining: 0,
-              scope: coupon.coupon_code.coupon_plan.scope,
-              productIds: coupon.coupon_code.coupon_plan.coupon_plan_products.map(
-                couponPlanProduct => couponPlanProduct.product_id,
-              ),
+  const fetch = useCallback(async () => {
+    if (authToken) {
+      const route = '/coupons'
+      try {
+        setLoading(true)
+        const { data } = await axios.get(`${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}${route}`, {
+          params: { memberId, includeDeleted: false },
+          headers: { authorization: `Bearer ${authToken}` },
+        })
+        setData(
+          data.map((coupon: CouponFromLodestarAPI) => ({
+            id: coupon.id,
+            status: coupon.status,
+            couponCode: {
+              code: coupon.couponCode.code,
+              couponPlan: {
+                id: coupon.couponCode.couponPlan.id,
+                startedAt: coupon.couponCode.couponPlan.startedAt
+                  ? new Date(coupon.couponCode.couponPlan.startedAt)
+                  : null,
+                endedAt: coupon.couponCode.couponPlan.endedAt ? new Date(coupon.couponCode.couponPlan.endedAt) : null,
+                type: coupon.couponCode.couponPlan.type === 1 ? 'cash' : 'percent',
+                constraint: coupon.couponCode.couponPlan.constraint,
+                amount: coupon.couponCode.couponPlan.amount,
+                title: coupon.couponCode.couponPlan.title,
+                description: coupon.couponCode.couponPlan.description || '',
+                scope: coupon.couponCode.couponPlan.scope,
+                productIds: coupon.couponCode.couponPlan.couponPlanProducts.map(
+                  couponPlanProduct => couponPlanProduct.productId,
+                ),
+              },
             },
-          },
-        }))
+          })) || [],
+        )
+      } catch (err) {
+        console.log(err)
+        setError(err)
+      } finally {
+        setLoading(false)
+      }
+    }
+  }, [authToken])
+
+  useEffect(() => {
+    fetch()
+  }, [fetch])
 
   return {
-    loadingCoupons: loading,
-    errorCoupons: error,
-    coupons,
-    refetchCoupons: refetch,
+    loading,
+    error,
+    data,
+    fetch,
   }
 }
 

--- a/src/pages/member/CouponCollectionAdminPage.tsx
+++ b/src/pages/member/CouponCollectionAdminPage.tsx
@@ -14,7 +14,7 @@ import { StyledTabList, StyledTabPanel } from '../GroupBuyingCollectionPage'
 const CouponCollectionAdminPage: React.VFC = () => {
   const { formatMessage } = useIntl()
   const { currentMemberId } = useAuth()
-  const { loadingCoupons, coupons } = useCouponCollection(currentMemberId || '')
+  const { loading: loadingCoupons, data: coupons } = useCouponCollection(currentMemberId || '')
   const [activeKey, setActiveKey] = useState('available')
 
   const tabContents = [

--- a/src/types/checkout.ts
+++ b/src/types/checkout.ts
@@ -67,8 +67,6 @@ export type CouponProps = {
       amount: number
       title: string
       description: string | null
-      count: number
-      remaining: number
       scope: string[] | null
       productIds?: string[]
     }

--- a/src/types/coupon.ts
+++ b/src/types/coupon.ts
@@ -1,0 +1,39 @@
+export type CouponFromLodestarAPI = {
+  id: string
+  memberId: string
+  createdAt: string
+  couponCode: CouponCode
+  status: CouponStatus
+}
+
+export type CouponStatus = {
+  outdated: boolean
+  used: boolean
+}
+
+export type CouponCode = {
+  id: string
+  code: string
+  deletedAt: string | null
+  couponPlan: CouponPlan
+  appId: string
+}
+
+export type CouponPlan = {
+  id: string
+  title: string
+  description: string | null
+  startedAt: string | null
+  endedAt: string | null
+  type: number // 1 - cash / 2 - percent
+  constraint: string | null
+  amount: number
+  scope: string[] | null
+  couponPlanProducts: CouponPlanProduct[]
+}
+
+export type CouponPlanProduct = {
+  id: string
+  couponPlanId: string
+  productId: string
+}


### PR DESCRIPTION
Replaced GraphQL coupon fetching with a RESTful API call to handle coupon collection data retrieval in `useCouponCollection`. This shifts data fetching to rely on a new endpoint provided by the Lodestar API. The client now uses Axios for handling HTTP requests and manages state with `useState`, `useEffect`, and `useCallback` hooks to better handle async operations. Removed redundant fields ('count' and 'remaining') from the `CouponProps` type definition. The consuming component `CouponCollectionAdminPage` also has updated props to align with the hook's new return values.

This change improves data consistency by centralizing the source of coupon data and simplifies the data-fetching logic, streamlining client-side state management.