### PR TITLE
fix: display noSearchEnrolledProgram and noSearchEnrollProgramPackage message condition

### DIFF
--- a/src/components/package/ProgramPackageCollectionBlock.tsx
+++ b/src/components/package/ProgramPackageCollectionBlock.tsx
@@ -242,7 +242,7 @@ const ProgramPackageCollectionBlock: React.VFC<{
       {programPackageEnrollment.length === 0 &&
         expiredProgramPackageEnrollment.length === 0 &&
         totalProgramCounts === 0 && <p>{formatMessage(commonMessages.content.noProgramPackage)}</p>}
-      {totalProgramPackageCounts > 0 && programPackage.length === 0 && (
+      {totalProgramPackageCounts > 0 && programPackage.length === 0 && search !== '' && (
         <p>{formatMessage(productMessages.programPackage.content.noSearchEnrolledProgramPackage)}</p>
       )}
     </div>

--- a/src/containers/program/EnrolledProgramCollectionBlock.tsx
+++ b/src/containers/program/EnrolledProgramCollectionBlock.tsx
@@ -308,7 +308,7 @@ const EnrolledProgramCollectionBlock: React.VFC<{
       {programEnrollment.length === 0 && expiredProgramEnrollment.length === 0 && totalProgramPackageCounts === 0 && (
         <p>{formatMessage(productMessages.program.content.noProgram)}</p>
       )}
-      {totalProgramCounts > 0 && programs.length === 0 && (
+      {totalProgramCounts > 0 && programs.length === 0 && search !== '' && (
         <p>{formatMessage(productMessages.program.content.noSearchEnrolledProgram)}</p>
       )}
     </div>


### PR DESCRIPTION
What
---
- Because in the process of solving the demand, I saw an no search message when not searching, so I corrected it.

### Before
<img width="1155" alt="image" src="https://github.com/urfit-tech/lodestar-app/assets/107075349/2649d1b9-3ee3-4b85-bb43-ae40c88d4b61">
<img width="1139" alt="image" src="https://github.com/urfit-tech/lodestar-app/assets/107075349/c12c3656-1a4c-4288-ba24-b8ef0ffa9e74">

### After
<img width="1169" alt="image" src="https://github.com/urfit-tech/lodestar-app/assets/107075349/b35390e2-c69b-4042-9227-572c0601648f">
<img width="1165" alt="image" src="https://github.com/urfit-tech/lodestar-app/assets/107075349/f61ddeaf-14a8-4eeb-8865-c869fa33008d">
