### PR TITLE
fix: video background mode cannot play

### DIFF
--- a/src/components/audio/GlobalAudioPlayer.tsx
+++ b/src/components/audio/GlobalAudioPlayer.tsx
@@ -120,6 +120,7 @@ const GlobalAudioPlayer: React.VFC = () => {
               contentType: programContent.contentType,
               videoId: programContentVideo.id,
               source: programContentVideo.options?.cloudflare ? 'cloudflare' : programContentVideo.data?.source,
+              cloudfront: programContentVideo.options?.cloudfront,
             })
           } else {
             close?.()
@@ -242,6 +243,7 @@ const GlobalAudioPlayer: React.VFC = () => {
               contentType: contentType || '',
               videoId: videos[0]?.id,
               source: videos[0]?.options?.cloudflare ? 'cloudflare' : videos[0]?.data?.source,
+              cloudfront: videos[0]?.options?.cloudfront,
             })
             if (pathname.includes('contents') && documentVisible) {
               history.push(`/programs/${programId}/contents/${contentId}`)

--- a/src/components/audio/PlaylistOverlay.tsx
+++ b/src/components/audio/PlaylistOverlay.tsx
@@ -220,6 +220,7 @@ const PlayListItem: React.VFC<{
             programId,
             contentId,
             contentType: contentType || '',
+            cloudfront: videos[0]?.options?.cloudfront,
           })
         }
       }}

--- a/src/contexts/AudioPlayerContext.tsx
+++ b/src/contexts/AudioPlayerContext.tsx
@@ -32,6 +32,7 @@ type AudioPlayerContextValue = {
     contentType?: string | null
     videoId?: string
     source?: string
+    cloudfront?: object
   }) => void
 }
 
@@ -64,6 +65,7 @@ export const AudioPlayerProvider: React.FC = ({ children }) => {
     backgroundMode: boolean
     contentType: string
     source: string
+    cloudfront?: object
   } = localPlaying !== null && JSON.parse(localPlaying)
   const [visible, setVisible] = useState(playing.visible || false)
   const [programId, setProgramId] = useState(playing.programId || '')
@@ -71,6 +73,7 @@ export const AudioPlayerProvider: React.FC = ({ children }) => {
   const [isBackgroundMode, setIsBackgroundMode] = useState(playing.backgroundMode || false)
   const [contentType, setContentType] = useState(playing.contentType || null)
   const [source, setSource] = useState(playing.source || '')
+  const [cloudfrontPath, setCloudfrontPath] = useState(playing.cloudfront)
   const [videoId, setVideoId] = useState(playing.videoId || '')
   const [isPlaying, setIsPlaying] = useState(false)
   const [title, setTitle] = useState('')
@@ -89,7 +92,32 @@ export const AudioPlayerProvider: React.FC = ({ children }) => {
       if (source === 'azure') {
         setMimeType('application/x-mpegURL')
         setAudioUrl(`${source}(format=m3u8-cmaf)`)
-      } else if (source === 'cloudflare') {
+      }
+
+      if (cloudfrontPath) {
+        axios
+          .get(`${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/videos/${videoId}/sign`, {
+            headers: {
+              Authorization: `Bearer ${authToken}`,
+            },
+          })
+          .then(({ data }) => {
+            const {
+              videoSignedPaths: { hlsPath, dashPath, cloudfrontMigratedHlsPath },
+            } = data.result
+
+            setMimeType('application/x-mpegURL')
+            setAudioUrl(
+              hlsPath && dashPath
+                ? `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/videos${hlsPath}`
+                : `${process.env.REACT_APP_LODESTAR_SERVER_ENDPOINT}/videos${cloudfrontMigratedHlsPath}`,
+            )
+          })
+
+        return
+      }
+
+      if (source === 'cloudflare') {
         axios
           .post(
             `${process.env.REACT_APP_API_BASE_ROOT}/videos/${videoId}/token`,
@@ -147,8 +175,17 @@ export const AudioPlayerProvider: React.FC = ({ children }) => {
           localStorage.setItem('audioPlayerVisibleState', 'close')
         },
         setup: options => {
-          const { title, contentSectionTitle, programId, contentId, backgroundMode, contentType, videoId, source } =
-            options
+          const {
+            title,
+            contentSectionTitle,
+            programId,
+            contentId,
+            backgroundMode,
+            contentType,
+            videoId,
+            source,
+            cloudfront,
+          } = options
           title && setTitle(title)
           contentSectionTitle && setContentSectionTitle(contentSectionTitle)
           programId && setProgramId(programId)
@@ -156,6 +193,7 @@ export const AudioPlayerProvider: React.FC = ({ children }) => {
           contentType && setContentType(contentType)
           videoId && setVideoId(videoId)
           source && setSource(source)
+          cloudfront && setCloudfrontPath(cloudfront)
           const playing = {
             backgroundMode,
             visible,
@@ -164,6 +202,7 @@ export const AudioPlayerProvider: React.FC = ({ children }) => {
             videoId,
             source,
             contentType,
+            cloudfront,
           }
           localStorage.setItem('playing', JSON.stringify(playing))
           localStorage.setItem('audioPlayerVisibleState', 'open')

--- a/src/pages/ProgramContentPage/ProgramContentBlock.tsx
+++ b/src/pages/ProgramContentPage/ProgramContentBlock.tsx
@@ -317,6 +317,7 @@ const ProgramContentBlock: React.VFC<{
                           source: programContent.videos[0]?.options?.cloudflare
                             ? 'cloudflare'
                             : programContent.videos[0]?.data?.source,
+                          cloudfront: programContent.videos[0]?.options?.cloudfront,
                         })
                         changeBackgroundMode?.(true)
                         changeGlobalPlayingState?.(true)

--- a/src/types/program.ts
+++ b/src/types/program.ts
@@ -115,7 +115,12 @@ export type ProgramContent = {
   salePrice: number | null
   soldAt: Date | null
   // materials?: ProgramContentMaterialProps[]
-  videos: { id: string; size: number; options: { cloudflare?: object }; data: { source?: string } }[]
+  videos: {
+    id: string
+    size: number
+    options: { cloudflare?: object; cloudfront?: object }
+    data: { source?: string }
+  }[]
   audios: { data: object }[]
   contentBodyId: string
   ebook: ProgramContentEbook


### PR DESCRIPTION
Title: Fix iOS Commute Mode Playback Issue and Update AudioPlayerContext

Description:

Objective (WHY):
To restore the normal functionality of the commute mode for iOS users and enhance the audio player's integration with the backend, ensuring smooth and reliable usage.

Current Issue:
On iOS devices, switching to commute mode results in an unresponsive player, indicated by a perpetual loading spinner. This issue affects users under the following conditions:

Device: iPhone 11
OS Version: 16.11
Browser: Safari
Modifications Made:

AudioPlayerContext.tsx: Integrated new API calls to lodestar-server, enhancing the AudioPlayerContext to better manage state and dependencies across different components and network conditions.
ProgramContentPlayer.tsx: Updated to utilize the enhanced AudioPlayerContext, ensuring more reliable interactions and data handling when in commute mode.
A demonstration video showing the issue and the environment in which testing was conducted is included for clarity. These changes aim to provide a seamless experience for iOS users in commute mode by addressing the playback issues and improving backend connectivity.

Before:
![image](https://github.com/urfit-tech/lodestar-app/assets/64723534/b0790389-2cb5-499a-9f34-59bc9605a1b8)

After:
