### PR TITLE
feat: ProgramContentEbookReader add trialComplete

### DIFF
--- a/src/components/program/translation.ts
+++ b/src/components/program/translation.ts
@@ -48,6 +48,13 @@ const programMessages = {
   ProgramSelector: defineMessages({
     allPrograms: { id: 'program.ProgramSelector.allPrograms', defaultMessage: '全部課程' },
   }),
+  ProgramContentEbookReader: defineMessages({
+    trialCompleted: { id: 'program.ProgramContentEbookReader.trialCompleted', defaultMessage: 'Trial Read Completed' },
+    trialCompletedMessage: {
+      id: 'program.ProgramContentEbookReader.trialCompletedMessage',
+      defaultMessage: 'The following content is more exciting, buy the full version now.',
+    },
+  }),
 }
 
 export default programMessages

--- a/src/hooks/ebook.ts
+++ b/src/hooks/ebook.ts
@@ -1,4 +1,6 @@
+import { gql, useQuery } from '@apollo/client'
 import { useCallback, useState } from 'react'
+import hasura from '../hasura'
 import {
   DeleteEbookHighlightRequestDto,
   Highlight,
@@ -167,4 +169,25 @@ export const useEbookHighlight = () => {
     deleteHighlight,
     updateHighlight,
   }
+}
+
+export const useGetEbookTrialPercentage = (programContentId: string) => {
+  const { data } = useQuery<hasura.GetEbookTrialPercentage, hasura.GetEbookTrialPercentageVariables>(
+    gql`
+      query GetEbookTrialPercentage($programContentId: uuid!) {
+        program_content_ebook(where: { program_content_id: { _eq: $programContentId } }) {
+          id
+          trial_percentage
+        }
+      }
+    `,
+    {
+      variables: {
+        programContentId,
+      },
+    },
+  )
+
+  const ebookTrialPercentage = data?.program_content_ebook[0].trial_percentage || 0
+  return ebookTrialPercentage
 }

--- a/src/pages/ProgramContentPage/ProgramContentBlock.tsx
+++ b/src/pages/ProgramContentPage/ProgramContentBlock.tsx
@@ -295,7 +295,7 @@ const ProgramContentBlock: React.VFC<{
         <ProgramContentEbookReader
           setEbook={setEbook}
           programContentId={programContent.id}
-          isTrial={programContent.displayMode === 'trial'}
+          isTrial={programContent.displayMode === 'trial' || programContent.displayMode === 'loginToTrial'}
           ebookCurrentToc={ebookCurrentToc}
           onEbookCurrentTocChange={onEbookCurrentTocChange}
           location={ebookLocation}

--- a/src/pages/ProgramPage/Primary/ProgramContentListSection.tsx
+++ b/src/pages/ProgramPage/Primary/ProgramContentListSection.tsx
@@ -51,7 +51,7 @@ const StyledPinnedIcon = styled.span<{ pin: boolean }>`
     `}
 `
 
-const MobileProgramContentItem = styled.div<{ isEnrolled: boolean }>`
+const StyledMobileProgramContentItem = styled.div<{ isEnrolled: boolean }>`
   position: relative;
   margin-bottom: 12px;
   padding: 1rem;
@@ -65,7 +65,7 @@ const MobileProgramContentItem = styled.div<{ isEnrolled: boolean }>`
   }
 `
 
-const ProgramContentItem = styled(MobileProgramContentItem)<{ isEnrolled: boolean }>`
+const StyledProgramContentItem = styled(StyledMobileProgramContentItem)<{ isEnrolled: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -225,12 +225,16 @@ const ProgramContentListSection: React.VFC<{
   }> = ({ item, isPinned }) => {
     if (item == null) return <></>
 
+    const isEbookTrial =
+      (item.contentType === 'ebook' && item.displayMode === DisplayModeEnum.trial) ||
+      item.displayMode === DisplayModeEnum.loginToTrial
+
     return (
       <>
         {isMobile ? (
           <div style={{ position: 'relative' }}>
             <StyledPinnedIcon pin={isPinned} />
-            <MobileProgramContentItem
+            <StyledMobileProgramContentItem
               key={item.id}
               isEnrolled={isEquityProgram}
               onClick={() => {
@@ -242,7 +246,7 @@ const ProgramContentListSection: React.VFC<{
                   url.searchParams.set('programContentId', item.id)
                   window.history.pushState({}, '', url.toString())
                   setAuthModalVisible?.(true)
-                } else if (item.contentType === 'ebook' && item.displayMode === DisplayModeEnum.trial) {
+                } else if (isEbookTrial) {
                   history.push(`/programs/${program.id}/contents/${item.id}?back=programs_${program.id}`)
                 }
               }}
@@ -300,14 +304,14 @@ const ProgramContentListSection: React.VFC<{
                     ` (${moment(item.publishedAt).format('MM/DD')} ${formatMessage(commonMessages.text.publish)}) `}
                 </span>
               </StyledDuration>
-            </MobileProgramContentItem>
+            </StyledMobileProgramContentItem>
           </div>
         ) : (
           <div style={{ position: 'relative' }}>
             <StyledPinnedIcon pin={isPinned} />
-            <ProgramContentItem
+            <StyledProgramContentItem
               key={item.id}
-              isEnrolled={isEquityProgram}
+              isEnrolled={isEquityProgram || isEbookTrial}
               onClick={() => {
                 if (isEquityProgram) {
                   history.push(`/programs/${program.id}/contents/${item.id}?back=programs_${program.id}`)
@@ -317,7 +321,7 @@ const ProgramContentListSection: React.VFC<{
                   url.searchParams.set('programContentId', item.id)
                   window.history.pushState({}, '', url.toString())
                   setAuthModalVisible?.(true)
-                } else if (item.contentType === 'ebook' && item.displayMode === DisplayModeEnum.trial) {
+                } else if (isEbookTrial) {
                   history.push(`/programs/${program.id}/contents/${item.id}?back=programs_${program.id}`)
                 }
               }}
@@ -376,7 +380,7 @@ const ProgramContentListSection: React.VFC<{
                 </span>
                 {durationFormatter(item.duration) || ''}
               </StyledDuration>
-            </ProgramContentItem>
+            </StyledProgramContentItem>
           </div>
         )}
       </>

--- a/src/pages/ProgramPage/Secondary/SecondaryProgramContentListItem.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryProgramContentListItem.tsx
@@ -42,7 +42,7 @@ const StyledMobileProgramContentItem = styled.div<{ isEnrolled: boolean }>`
   }
 `
 
-const ProgramContentItem = styled(StyledMobileProgramContentItem)<{ isEnrolled: boolean }>`
+const StyledProgramContentItem = styled(StyledMobileProgramContentItem)<{ isEnrolled: boolean }>`
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -83,6 +83,10 @@ const SecondaryProgramContentListItem: React.VFC<{
   const { isAuthenticated } = useAuth()
   const { setVisible: setAuthModalVisible } = useContext(AuthModalContext)
 
+  const isEbookTrial =
+    (item.contentType === 'ebook' && item.displayMode === DisplayModeEnum.trial) ||
+    item.displayMode === DisplayModeEnum.loginToTrial
+
   useEffect(() => {
     const autoScroll = setTimeout(() => {
       const url = new URL(window.location.href)
@@ -121,7 +125,7 @@ const SecondaryProgramContentListItem: React.VFC<{
                 url.searchParams.set('programContentId', item.id)
                 window.history.pushState({}, '', url.toString())
                 setAuthModalVisible?.(true)
-              } else if (item.contentType === 'ebook' && item.displayMode === DisplayModeEnum.trial) {
+              } else if (isEbookTrial) {
                 history.push(`/programs/${program.id}/contents/${item.id}?back=programs_${program.id}`)
               }
             }}
@@ -184,9 +188,9 @@ const SecondaryProgramContentListItem: React.VFC<{
       ) : (
         <div style={{ position: 'relative' }}>
           <StyledPinnedIcon pin={isPinned} />
-          <ProgramContentItem
+          <StyledProgramContentItem
             key={item.id}
-            isEnrolled={isEquityProgram}
+            isEnrolled={isEquityProgram || isEbookTrial}
             onClick={() => {
               if (isEquityProgram) {
                 history.push(`/programs/${program.id}/contents/${item.id}?back=programs_${program.id}`)
@@ -196,7 +200,7 @@ const SecondaryProgramContentListItem: React.VFC<{
                 url.searchParams.set('programContentId', item.id)
                 window.history.pushState({}, '', url.toString())
                 setAuthModalVisible?.(true)
-              } else if (item.contentType === 'ebook' && item.displayMode === DisplayModeEnum.trial) {
+              } else if (isEbookTrial) {
                 history.push(`/programs/${program.id}/contents/${item.id}?back=programs_${program.id}`)
               }
             }}
@@ -255,7 +259,7 @@ const SecondaryProgramContentListItem: React.VFC<{
               </span>
               {durationFormatter(item.duration) || ''}
             </StyledDuration>
-          </ProgramContentItem>
+          </StyledProgramContentItem>
         </div>
       )}
     </>

--- a/src/translations/locales/en-us.json
+++ b/src/translations/locales/en-us.json
@@ -1130,6 +1130,8 @@
   "program.ProgramContentMenu.unit": "單元排序",
   "program.ProgramContentNoAuthBlock.noAuth": "沒有此頁瀏覽權限",
   "program.ProgramContentPlayer.next": "接下來",
+  "program.ProgramContentEbookReader.trialCompleted": "Trial Read Completed",
+  "program.ProgramContentEbookReader.trialCompletedMessage": "The following content will be more exciting, buy the full version now.",
   "program.ProgramDisplayedListItem.expiredAt": "到期",
   "program.ProgramSelector.allPrograms": "全部課程",
   "program.label.cover": "Cover Image",

--- a/src/translations/locales/id.json
+++ b/src/translations/locales/id.json
@@ -1132,6 +1132,8 @@
   "program.ProgramContentPlayer.next": "接下來",
   "program.ProgramDisplayedListItem.expiredAt": "到期",
   "program.ProgramSelector.allPrograms": "全部課程",
+  "program.ProgramContentEbookReader.trialCompleted": "Percobaan pembacaan selesai",
+  "program.ProgramContentEbookReader.trialCompletedMessage": "Konten berikut akan lebih seru, beli versi lengkapnya sekarang",
   "program.label.cover": "Gambar Sampul",
   "program.label.coverNotice": "Ukuran gambar unggahan yang disarankan adalah 1600*900px",
   "program.label.editPractice": "Edit Pekerjaan",

--- a/src/translations/locales/vi.json
+++ b/src/translations/locales/vi.json
@@ -1132,6 +1132,8 @@
   "program.ProgramContentPlayer.next": "接下來",
   "program.ProgramDisplayedListItem.expiredAt": "到期",
   "program.ProgramSelector.allPrograms": "全部課程",
+  "program.ProgramContentEbookReader.trialCompleted": "Đọc thử đã hoàn tất",
+  "program.ProgramContentEbookReader.trialCompletedMessage": "Nội dung sau sẽ thú vị hơn, hãy mua phiên bản đầy đủ ngay",
   "program.label.cover": "Ảnh bìa",
   "program.label.coverNotice": "Kích thước hình ảnh tải lên được đề xuất là 1600 * 900px",
   "program.label.editPractice": "Chỉnh sửa Công việc",

--- a/src/translations/locales/zh-cn.json
+++ b/src/translations/locales/zh-cn.json
@@ -1132,6 +1132,8 @@
   "program.ProgramContentPlayer.next": "接下來",
   "program.ProgramDisplayedListItem.expiredAt": "到期",
   "program.ProgramSelector.allPrograms": "全部課程",
+  "program.ProgramContentEbookReader.trialCompleted": "试阅完毕",
+  "program.ProgramContentEbookReader.trialCompletedMessage": "后面内容更精彩，立即购买完整版",
   "program.label.cover": "封面图片",
   "program.label.coverNotice": "建议上传图片尺寸为1600*900px",
   "program.label.editPractice": "编辑作业",

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -1129,6 +1129,8 @@
   "program.ProgramContentMenu.totalAmount": "共 {count} 題",
   "program.ProgramContentMenu.unit": "單元排序",
   "program.ProgramContentNoAuthBlock.noAuth": "沒有此頁瀏覽權限",
+  "program.ProgramContentEbookReader.trialCompleted": "試閱完畢",
+  "program.ProgramContentEbookReader.trialCompletedMessage": "後面內容更精彩，立即購買完整版",
   "program.ProgramContentPlayer.next": "接下來",
   "program.ProgramDisplayedListItem.expiredAt": "到期",
   "program.ProgramSelector.allPrograms": "全部課程",


### PR DESCRIPTION
# WHY

# WHAT
- The conditions for completing the trial reading of the e-book are:
  - `contentType` is e-book.
  - `displayMode` is `trial` or `loginToTrial`.
  - `sliderPercentage` is greater than or equal to `ebookTrialPercentage`.
- Add `CommonModal` to `ProgramContentEbookReader` and display it when the e-book trial is completed.
- Disable the right page turning behavior when the e-book trial is completed.
- Move `sliderOnChangeEnd` to `onChange` and rename it to `handleSliderChange` to fix the bug of page jumping when turning pages.
- Add isEnrolled of `ProgramContentItem` in `ProgramContentListSection` as a condition for previewing e-books to fix the display bug where the mouse finger does not appear.