### PR TITLE
feat: EbookProgramPageContent trial button link and purchase button link

### DIFF
--- a/src/components/program/ProgramContentEbookReader.tsx
+++ b/src/components/program/ProgramContentEbookReader.tsx
@@ -1,5 +1,5 @@
 import { gql, useApolloClient, useMutation, useQuery } from '@apollo/client'
-import { Box, Button, Flex, Spinner, Text } from '@chakra-ui/react'
+import { Box, Button, Flex, Link, Spinner, Text } from '@chakra-ui/react'
 import axios from 'axios'
 import { inRange } from 'lodash'
 import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
@@ -8,6 +8,7 @@ import { handleError } from 'lodestar-app-element/src/helpers'
 import { useCallback, useContext, useEffect, useLayoutEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
 import { EpubView, ReactReaderStyle } from 'react-reader'
+import { useParams } from 'react-router'
 import styled from 'styled-components'
 import { ProgressContext } from '../../contexts/ProgressContext'
 import hasura from '../../hasura'
@@ -146,6 +147,7 @@ const ProgramContentEbookReader: React.VFC<{
   isTrial,
 }) => {
   const { currentMemberId, authToken } = useAuth()
+  const { programId } = useParams<{ programId: string }>()
   const [source, setSource] = useState<ArrayBuffer | null>(null)
   const apolloClient = useApolloClient()
   const rendition = useRef<Rendition | undefined>(undefined)
@@ -585,7 +587,11 @@ const ProgramContentEbookReader: React.VFC<{
         onClose={() => {
           setModalState(null)
         }}
-        renderFooter={() => <Button colorScheme="primary">{formatMessage(commonMessages.ui.purchase)}</Button>}
+        renderFooter={() => (
+          <Link href={`/programs/${programId}?visitIntro=1`}>
+            <Button colorScheme="primary">{formatMessage(commonMessages.ui.purchase)}</Button>
+          </Link>
+        )}
       >
         <Text marginTop="16px">{formatMessage(programMessages.ProgramContentEbookReader.trialCompletedMessage)}</Text>
       </CommonModal>

--- a/src/pages/ProgramPage/Ebook/EbookProgramPageContent/index.tsx
+++ b/src/pages/ProgramPage/Ebook/EbookProgramPageContent/index.tsx
@@ -1,4 +1,4 @@
-import { Box, Button, Flex, Image, Text } from '@chakra-ui/react'
+import { Box, Button, Flex, Image, Link, Text } from '@chakra-ui/react'
 import { BraftContent } from 'lodestar-app-element/src/components/common/StyledBraftEditor'
 import { desktopViewMixin } from 'lodestar-app-element/src/helpers'
 import { useContext, useEffect, useRef, useState } from 'react'
@@ -94,6 +94,17 @@ const EbookProgramPageContent: React.VFC<{
     }
   }, [loadingProgramPlansEnrollmentsAggregateList])
 
+  const hasEbookTrialSection = program.contentSections.find(section =>
+    section.contents.some(content => {
+      const isTrial = content?.displayMode === 'trial' || content?.displayMode === 'loginToTrial'
+      return isTrial && content.contentType === 'ebook'
+    }),
+  )
+  const ebookTrialContent = hasEbookTrialSection?.contents.find(content => {
+    const isTrial = content?.displayMode === 'trial' || content?.displayMode === 'loginToTrial'
+    return isTrial && content.contentType === 'ebook'
+  })
+
   return (
     <div>
       <StyledProgramIntroBlock>
@@ -106,7 +117,9 @@ const EbookProgramPageContent: React.VFC<{
                     <Image src={coverUrl || ''} alt="cover" />
                   </Box>
                   <Flex alignItems="center" gridGap="2" width="100%">
-                    <StyledButton>試閱</StyledButton>
+                    <Link href={`/programs/${program.id}/contents/${ebookTrialContent?.id}`} width="100%">
+                      <StyledButton>試閱</StyledButton>
+                    </Link>
                     <Box width="20%" display="flex" justifyContent="center">
                       <SocialSharePopover url={window.location.href}>
                         <FaShareAlt color="#9b9b9b" fontSize="20px" />


### PR DESCRIPTION
# WHY
- There is no response when clicking the "Trial" button in EbookProgramPageContent and the "Buy Now" button in the window that appears after the trial is completed.

# WHAT
- First, find the first unit that matches the displayMode of "Trial" or "loginToTrial" and the contentType of ebook, and add the link component of chakra-ui outside the "Trial" button in EbookProgramPageContent. When clicked, the link to the above qualified unit is triggered.
- Add the Link Component of chakra-ui outside the "Buy Now" button and link it to the program intro page.