### PR TITLE
style: size down the cover label, add shadow for the del price, and c…

### DIFF
--- a/src/pages/ProgramPage/Secondary/SecondaryProgramBanner.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryProgramBanner.tsx
@@ -99,16 +99,12 @@ const StyledCoverLabel = styled.div`
   display: flex;
   justify-content: center;
   align-items: center;
-  margin-top: 16px;
-  padding: 6px;
-  width: 100px;
-  height: 45px;
+  font-size: 0.8rem;
+  padding: 0.4rem;
+  height: 1.8rem;
   background-color: ${colors.orange};
   font-weight: 600;
   color: ${colors.white};
-  @media (min-width: ${BREAK_POINT}px) {
-    width: 100px;
-  }
 `
 
 const PreviewButton = styled(SecondaryOutlineButton)`
@@ -263,7 +259,11 @@ const SecondaryProgramBanner: React.VFC<{
                             })}
                       </EnrollButton>
                       {firstPublishProgramPlan?.salePrice !== null && (
-                        <Text as="del" marginLeft="4px">{`$${firstPublishProgramPlan?.listPrice}`}</Text>
+                        <Text
+                          as="del"
+                          style={{ color: '#D3D3D3', textShadow: '2px 2px 3px #333333', padding: '2px' }}
+                          marginLeft="4px"
+                        >{`$${firstPublishProgramPlan?.listPrice}`}</Text>
                       )}
                     </StyledSaleButtonWrapper>
                   </>

--- a/src/pages/ProgramPage/Secondary/SecondaryProgramPlanCard/SecondaryPriceLabel.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryProgramPlanCard/SecondaryPriceLabel.tsx
@@ -72,7 +72,13 @@ const SecondaryPriceLabel: React.VFC<{
             {salePriceSuffix}
             {periodElem}
           </StyledDisplayPrice>
-          <StyledPriceDescription>
+          <StyledPriceDescription
+            style={{
+              display: 'flex',
+              flexDirection: 'column',
+              alignItems: 'center',
+            }}
+          >
             <Text as="del">
               {listPricePrefix}
               {formatCurrency(listPrice)}


### PR DESCRIPTION
<img width="452" alt="截圖 2025-03-10 下午1 01 56" src="https://github.com/user-attachments/assets/21eb9c43-9ee4-4b72-8567-f0f726fefc05" />
<img width="387" alt="截圖 2025-03-10 下午1 02 09" src="https://github.com/user-attachments/assets/17e0d4b1-1467-4e9c-a4e9-4a9ce19e27ea" />

＊將小標籤依照知識衛星樣板調小

<img width="477" alt="截圖 2025-03-10 下午3 08 31" src="https://github.com/user-attachments/assets/01c4fec2-46f6-48a0-b573-5b638fab4f00" />

＊調整原價顏色，不被後面圖片影響

<img width="322" alt="截圖 2025-03-10 下午3 08 38" src="https://github.com/user-attachments/assets/ecf53281-2ab3-4613-934a-4798d9b47935" />

＊將原價與價格描述置中