### PR TITLE
feat: disable payment link for completed, expired, deleted, or refund…

### DIFF
--- a/src/hooks/program.ts
+++ b/src/hooks/program.ts
@@ -155,11 +155,15 @@ export const usePublishedProgramCollection = (options?: {
             labelColorType: program.label_color_type || '',
             isEnrolledCountVisible: program.is_enrolled_count_visible,
             categories: program.program_categories
-              .map(programCategory => ({
-                id: programCategory.category.id,
-                name: programCategory.category.name,
-                position: programCategory.category.position,
-              }))
+              .map(programCategory => {
+                return programCategory.category
+                  ? {
+                      id: programCategory.category.id,
+                      name: programCategory.category.name,
+                      position: programCategory.category.position,
+                    }
+                  : null
+              })
               .filter(category => category !== null),
             roles: program.program_roles.map(programRole => ({
               id: programRole.id,

--- a/src/hooks/program.ts
+++ b/src/hooks/program.ts
@@ -155,16 +155,12 @@ export const usePublishedProgramCollection = (options?: {
             labelColorType: program.label_color_type || '',
             isEnrolledCountVisible: program.is_enrolled_count_visible,
             categories: program.program_categories
-              .map(programCategory => {
-                return programCategory.category
-                  ? {
-                      id: programCategory.category.id,
-                      name: programCategory.category.name,
-                      position: programCategory.category.position,
-                    }
-                  : null
-              })
-              .filter(category => category !== null),
+              .filter(category => category !== null)
+              .map(programCategory => ({
+                id: programCategory.category.id,
+                name: programCategory.category.name,
+                position: programCategory.category.position,
+              })),
             roles: program.program_roles.map(programRole => ({
               id: programRole.id,
               name: programRole.name as ProgramRoleName,

--- a/src/pages/OrderPaymentPage.tsx
+++ b/src/pages/OrderPaymentPage.tsx
@@ -125,6 +125,7 @@ const OrderPaymentPage = () => {
   const [token] = useQueryParam('token', StringParam)
   const [order, setOrder] = useState<Order>()
   const [loading, setLoading] = useState(false)
+  const { formatMessage } = useIntl()
 
   useEffect(() => {
     setLoading(true)
@@ -146,21 +147,22 @@ const OrderPaymentPage = () => {
       .finally(() => {
         setLoading(false)
       })
-}, [appId, orderId, token])
-return (
-  <DefaultLayout>
-    {loading ? (
-      <Skeleton active />
-    ) : !order ? (
-      <>No order information available.</>  
-    ) : (
-      <OrderPaymentBlock order={order} />
-    )}
-  </DefaultLayout>
-)}
+  }, [appId, orderId, token])
+  return (
+    <DefaultLayout>
+      {loading ? (
+        <Skeleton active />
+      ) : !order ? (
+        <>{formatMessage(pageMessages.OrderPaymentPage.noOrderInformation)}</>
+      ) : (
+        <OrderPaymentBlock order={order} />
+      )}
+    </DefaultLayout>
+  )
+}
 
-const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => { 
-  const { formatMessage } = useIntl()  
+const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => {
+  const { formatMessage } = useIntl()
   const [selectedPayment, setSelectedPayment] = useState<Payment>()
   const unpaidPayments = order.paymentLogs
     .filter(p => p.status === 'UNPAID')
@@ -188,7 +190,7 @@ const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => {
         {formatMessage(pageMessages.OrderPaymentPage.paymentMethod)}
       </Typography.Title>
       {!unpaidPayments || hasInvalidOrderStatus || unpaidPayments.length === 0 ? (
-        <AdminCard>無付款資訊</AdminCard>
+        <AdminCard>{formatMessage(pageMessages.OrderPaymentPage.noPaymentInformation)}</AdminCard>
       ) : unpaidPayments.length === 1 || selectedPayment ? (
         <PaymentBlock
           order={order}

--- a/src/pages/OrderPaymentPage.tsx
+++ b/src/pages/OrderPaymentPage.tsx
@@ -146,19 +146,30 @@ const OrderPaymentPage = () => {
       .finally(() => {
         setLoading(false)
       })
-  }, [appId, orderId, token])
-  return <DefaultLayout>{loading ? <Skeleton active /> : <OrderPaymentBlock order={order} />}</DefaultLayout>
-}
+}, [appId, orderId, token])
+return (
+  <DefaultLayout>
+    {loading ? (
+      <Skeleton active />
+    ) : !order ? (
+      <>No order information available.</>  
+    ) : (
+      <OrderPaymentBlock order={order} />
+    )}
+  </DefaultLayout>
+)}
 
-const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => {
-  const { formatMessage } = useIntl()
+const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => { 
+  const { formatMessage } = useIntl()  
   const [selectedPayment, setSelectedPayment] = useState<Payment>()
-  const unpaidPayments = order?.paymentLogs
+  const unpaidPayments = order.paymentLogs
     .filter(p => p.status === 'UNPAID')
     .sort((a, b) => Number(a.no[a.no.length - 1]) - Number(b.no[b.no.length - 1]))
 
-  const invoice = order?.invoiceOptions?.invoices?.[0]
-  const orderProducts = order?.orderProducts || []
+  const invoice = order.invoiceOptions?.invoices?.[0]
+  const orderProducts = order.orderProducts || []
+  const invalidPaymentStatuses = ['SUCCESS', 'REFUND', 'EXPIRED', 'DELETED']
+  const hasInvalidOrderStatus = invalidPaymentStatuses.includes(order.status)
 
   return (
     <div className="container py-5">
@@ -176,8 +187,8 @@ const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => {
         <AntdIcon type="shopping-cart" className="mr-2" />
         {formatMessage(pageMessages.OrderPaymentPage.paymentMethod)}
       </Typography.Title>
-      {!order || !unpaidPayments || unpaidPayments.length === 0 ? (
-        <AdminCard>{formatMessage(pageMessages.OrderPaymentPage.noPaymentInformation)}</AdminCard>
+      {!unpaidPayments || hasInvalidOrderStatus || unpaidPayments.length === 0 ? (
+        <AdminCard>無付款資訊</AdminCard>
       ) : unpaidPayments.length === 1 || selectedPayment ? (
         <PaymentBlock
           order={order}

--- a/src/pages/OrderPaymentPage.tsx
+++ b/src/pages/OrderPaymentPage.tsx
@@ -148,23 +148,18 @@ const OrderPaymentPage = () => {
         setLoading(false)
       })
   }, [appId, orderId, token])
-  return (
-    <DefaultLayout>
-      {loading ? (
-        <Skeleton active />
-      ) : !order ? (
-        <>{formatMessage(pageMessages.OrderPaymentPage.noOrderInformation)}</>
-      ) : (
-        <OrderPaymentBlock order={order} />
-      )}
-    </DefaultLayout>
-  )
+  return <DefaultLayout>{loading ? <Skeleton active /> : <OrderPaymentBlock order={order} />}</DefaultLayout>
 }
 
-const OrderPaymentBlock: React.VFC<{ order: Order }> = ({ order }) => {
+const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => {
   const { formatMessage } = useIntl()
   const [selectedPayment, setSelectedPayment] = useState<Payment>()
-  const unpaidPayments = order.paymentLogs
+
+  if (!order) {
+    return <>{formatMessage(pageMessages.OrderPaymentPage.noOrderInformation)}</>
+  }
+
+  const unpaidPayments = (order.paymentLogs || [])
     .filter(p => p.status === 'UNPAID')
     .sort((a, b) => Number(a.no[a.no.length - 1]) - Number(b.no[b.no.length - 1]))
 

--- a/src/pages/OrderPaymentPage.tsx
+++ b/src/pages/OrderPaymentPage.tsx
@@ -161,7 +161,7 @@ const OrderPaymentPage = () => {
   )
 }
 
-const OrderPaymentBlock: React.VFC<{ order?: Order }> = ({ order }) => {
+const OrderPaymentBlock: React.VFC<{ order: Order }> = ({ order }) => {
   const { formatMessage } = useIntl()
   const [selectedPayment, setSelectedPayment] = useState<Payment>()
   const unpaidPayments = order.paymentLogs

--- a/src/pages/translation.ts
+++ b/src/pages/translation.ts
@@ -18,7 +18,7 @@ const pageMessages = {
     },
     noOrderInformation: {
       id: 'page.OrderPaymentPage.noOrderInformation',
-      defaultMessage: 'No order information available.',
+      defaultMessage: 'No order information available',
     },
     goToCheckout: {
       id: 'page.OrderPaymentPage.goToCheckout',

--- a/src/pages/translation.ts
+++ b/src/pages/translation.ts
@@ -16,6 +16,10 @@ const pageMessages = {
       id: 'page.OrderPaymentPage.noPaymentInformation',
       defaultMessage: 'No Payment Information',
     },
+    noOrderInformation: {
+      id: 'page.OrderPaymentPage.noOrderInformation',
+      defaultMessage: 'No order information available.',
+    },
     goToCheckout: {
       id: 'page.OrderPaymentPage.goToCheckout',
       defaultMessage: 'Go to checkout',

--- a/src/translations/locales/en-us.json
+++ b/src/translations/locales/en-us.json
@@ -1040,6 +1040,7 @@
   "page.CollapseContentBlock.podcastChannel": "Podcast Channels ({count})",
   "page.OrderPaymentPage.paymentInformation": "Payment Information",
   "page.OrderPaymentPage.noPaymentInformation": "No payment information",
+  "page.OrderPaymentPage.noOrderInformation": "No order information available",
   "page.OrderPaymentPage.goToCheckout": "Go to payment",
   "page.OrderPaymentPage.paymentMethod": "Payment Method",
   "page.OrderPaymentPage.contractBlock": "Please expand this section, read carefully, and sign the contract.",

--- a/src/translations/locales/id.json
+++ b/src/translations/locales/id.json
@@ -1040,6 +1040,7 @@
   "page.CollapseContentBlock.podcastChannel": "Saluran podcast({count})",
   "page.OrderPaymentPage.paymentInformation": "Informasi Pembayaran",
   "page.OrderPaymentPage.noPaymentInformation": "Tidak ada informasi pembayaran",
+  "page.OrderPaymentPage.noOrderInformation": "Tidak ada informasi pesanan yang tersedia",
   "page.OrderPaymentPage.goToCheckout": "Buka pembayaran",
   "page.OrderPaymentPage.paymentMethod": "Metode Pembayaran",
   "page.OrderPaymentPage.contractBlock": "Harap perluas bagian ini, baca dengan saksama, dan tanda tangani kontrak.",

--- a/src/translations/locales/ja.json
+++ b/src/translations/locales/ja.json
@@ -1036,6 +1036,7 @@
   "page.CollapseContentBlock.podcastChannel": "ポッドキャストチャンネル({count})",
   "page.OrderPaymentPage.paymentInformation": "支払い情報",
   "page.OrderPaymentPage.noPaymentInformation": "支払い情報がありません",
+  "page.OrderPaymentPage.noOrderInformation": "注文情報がありません",
   "page.OrderPaymentPage.goToCheckout": "支払いに進む",
   "page.OrderPaymentPage.paymentMethod": "支払い方法",
   "page.OrderPaymentPage.contractBlock": "このセクションを展開し、よく読んで契約書に署名してください。",

--- a/src/translations/locales/ko.json
+++ b/src/translations/locales/ko.json
@@ -1036,6 +1036,7 @@
   "page.CollapseContentBlock.podcastChannel": "팟캐스트 채널({count})",
   "page.OrderPaymentPage.paymentInformation": "결제 정보",
   "page.OrderPaymentPage.noPaymentInformation": "결제 정보 없음",
+  "page.OrderPaymentPage.noOrderInformation": "주문 정보가 없습니다",
   "page.OrderPaymentPage.goToCheckout": "결제로 이동",
   "page.OrderPaymentPage.paymentMethod": "결제 방법",
   "page.OrderPaymentPage.contractBlock": "이 섹션을 확장하고 주의 깊게 읽고 계약서에 서명하세요.",

--- a/src/translations/locales/vi.json
+++ b/src/translations/locales/vi.json
@@ -1040,6 +1040,7 @@
   "page.CollapseContentBlock.podcastChannel": "Kênh podcast({count})",
   "page.OrderPaymentPage.paymentInformation": "Thông tin thanh toán",
   "page.OrderPaymentPage.noPaymentInformation": "Không có thông tin thanh toán",
+  "page.OrderPaymentPage.noOrderInformation": "Không có thông tin đơn hàng",
   "page.OrderPaymentPage.goToCheckout": "Đi đến mục thanh toán",
   "page.OrderPaymentPage.paymentMethod": "Phương thức thanh toán",
   "page.OrderPaymentPage.contractBlock": "Vui lòng mở rộng phần này, đọc kỹ và ký hợp đồng.",

--- a/src/translations/locales/zh-cn.json
+++ b/src/translations/locales/zh-cn.json
@@ -1040,6 +1040,7 @@
   "page.CollapseContentBlock.podcastChannel": "广播频道({count})",
   "page.OrderPaymentPage.paymentInformation": "付款信息",
   "page.OrderPaymentPage.noPaymentInformation": "无付款信息",
+  "page.OrderPaymentPage.noOrderInformation": "没有订单信息",
   "page.OrderPaymentPage.goToCheckout": "前往付款",
   "page.OrderPaymentPage.paymentMethod": "付款方式",
   "page.OrderPaymentPage.contractBlock": "请展开此部分，仔细阅读，并签署合同。",

--- a/src/translations/locales/zh-tw.json
+++ b/src/translations/locales/zh-tw.json
@@ -1040,6 +1040,7 @@
   "page.CollapseContentBlock.podcastChannel": "廣播頻道({count})",
   "page.OrderPaymentPage.paymentInformation": "付款資訊",
   "page.OrderPaymentPage.noPaymentInformation": "無付款資訊",
+  "page.OrderPaymentPage.noOrderInformation": "沒有訂單資訊",
   "page.OrderPaymentPage.goToCheckout": "前往付款",
   "page.OrderPaymentPage.paymentMethod": "付款方式",
   "page.OrderPaymentPage.contractBlock": "請展開此區塊，詳閱並簽署合約",


### PR DESCRIPTION
修正當訂單狀態為「已完成」、「已失效」、「已刪除」、「已退款」時，付款連結仍可開啟的問題。

- 若顧問或學員透過「複製付款連結」按鈕產生連結並開啟，若該訂單狀態為上述任一狀態，則付款連結將失效，導向無付款資訊畫面，避免誤付款。
- Trello 卡片：https://trello.com/c/UCdhdVdc