### PR TITLE
feat:header bg-color use primary-color control by app setting

### DIFF
--- a/src/components/layout/DefaultLayout/DefaultLayout.styled.tsx
+++ b/src/components/layout/DefaultLayout/DefaultLayout.styled.tsx
@@ -5,15 +5,20 @@ import styled, { css } from 'styled-components'
 import { desktopViewMixin } from '../../../helpers'
 import { BREAK_POINT } from '../../common/Responsive'
 
+interface StyledUsePrimaryColorProps {
+  usePrimaryColor?: boolean
+}
+
 export const StyledLayout = styled(Layout)<{ variant?: 'white'; header?: string }>`
   ${props => (props.variant === 'white' ? 'background: white;' : '')}
   ${props => (props.header === 'noHeader' ? ' .ant-layout-content { padding-top: 0px;}' : '')}
 `
-export const StyledLayoutHeader = styled(Layout.Header)`
+export const StyledLayoutHeader = styled(Layout.Header)<StyledUsePrimaryColorProps>`
   position: sticky;
   position: -webkit-sticky;
   height: 4rem;
   top: 0;
+  background: ${props => (props.usePrimaryColor ? props.theme['@primary-color'] : '#ffffff')};
   z-index: 1000;
 
   &.hidden {
@@ -49,17 +54,17 @@ export const StyledNavTag = styled(Tag)`
     font-size: 12px;
   }
 `
-export const StyledNavButton = styled(Button)`
+export const StyledNavButton = styled(Button)<StyledUsePrimaryColorProps>`
   &&& {
-    background: #ffffff;
+    background: ${props => (props.usePrimaryColor ? props.theme['@primary-color'] : '#ffffff')};
     height: 4rem;
     color: #585858;
     line-height: 1.5;
   }
 `
-export const StyledNavAnimationButton = styled(Button)`
+export const StyledNavAnimationButton = styled(Button)<StyledUsePrimaryColorProps>`
   &&& {
-    background: #ffffff;
+    background: ${props => (props.usePrimaryColor ? props.theme['@primary-color'] : '#ffffff')};
     height: 4rem;
     color: #585858;
     line-height: 1.5;

--- a/src/components/layout/DefaultLayout/index.tsx
+++ b/src/components/layout/DefaultLayout/index.tsx
@@ -98,6 +98,8 @@ const DefaultLayout: React.FC<{
 
   const isUnVerifiedEmails = member ? !member.verifiedEmails?.includes(member.email) : false
 
+  const isPrimaryColorEnabled = Boolean(Number(settings['theme.@primary_color.enabled']))
+
   return (
     <AuthModalContext.Provider value={{ visible, setVisible, isBusinessMember, setIsBusinessMember }}>
       {visible && (
@@ -116,6 +118,7 @@ const DefaultLayout: React.FC<{
         {!noHeader ? (
           <StyledLayoutHeader
             className={`d-flex align-items-center justify-content-between ${noHeader ? 'hidden' : ''}`}
+            usePrimaryColor={isPrimaryColorEnabled}
           >
             <div className="d-flex align-items-center">
               <LogoBlock className="mr-4">
@@ -139,6 +142,7 @@ const DefaultLayout: React.FC<{
                               ? StyledNavAnimationButton
                               : StyledNavButton
                           }
+                          usePrimaryColor={isPrimaryColorEnabled}
                           onClick={() => {
                             nav.href && window.open(nav.href, '_blank', 'noopener=yes,noreferrer=yes')
                           }}
@@ -159,6 +163,7 @@ const DefaultLayout: React.FC<{
                               ? StyledNavAnimationButton
                               : StyledNavButton
                           }
+                          usePrimaryColor={isPrimaryColorEnabled}
                           onClick={e => {
                             if (nav.href) {
                               if (nav.href[0] === '/') {
@@ -225,6 +230,7 @@ const DefaultLayout: React.FC<{
                               ? StyledNavAnimationButton
                               : StyledNavButton
                           }
+                          usePrimaryColor={isPrimaryColorEnabled}
                           onClick={() => history.push(`/creators/${currentMemberId}`)}
                         >
                           <Link to={`/creators/${currentMemberId}`}>
@@ -246,6 +252,7 @@ const DefaultLayout: React.FC<{
                               ? StyledNavAnimationButton
                               : StyledNavButton
                           }
+                          usePrimaryColor={isPrimaryColorEnabled}
                           onClick={() => history.push(`/members/${currentMemberId}`)}
                         >
                           <Link to={`/members/${currentMemberId}`}>


### PR DESCRIPTION
<img width="1209" alt="截圖 2025-07-07 下午1 39 46" src="https://github.com/user-attachments/assets/dcec8e00-439b-432b-8c64-7a55084eb577" />
<img width="1509" alt="截圖 2025-07-07 下午1 39 13" src="https://github.com/user-attachments/assets/30384122-8e0a-48e8-896f-f3c1848a905f" />

當 app_setting 中，設定  theme.@primary_color.enabled = 1 時，會使用primari-color