### PR TITLE
feat: global_search.minute_interval default value

### DIFF
--- a/src/components/layout/DefaultLayout/GlobalSearchModal.tsx
+++ b/src/components/layout/DefaultLayout/GlobalSearchModal.tsx
@@ -438,7 +438,12 @@ const GlobalSearchFilter: React.FC<{
           <StyledFilterSubTitle className="mb-2">
             {formatMessage(defineMessage({ id: 'common.ui.duration', defaultMessage: '時長（分鐘）' }))}
           </StyledFilterSubTitle>
-          {[0, ...settings['global_search.minute_interval'].split(',').map(Number)].map((minute, i, minutes) => (
+          {[
+            0,
+            ...(settings['global_search.minute_interval']
+              ? settings['global_search.minute_interval'].split(',').map(Number)
+              : [5, 10]),
+          ].map((minute, i, minutes) => (
             <StyledRoundedButton
               onClick={() => {
                 onFilterSet(prevFilter => ({


### PR DESCRIPTION
<img width="679" height="153" alt="image" src="https://github.com/user-attachments/assets/24a5893c-9546-4c14-8f79-c87d040adb22" />

fix `global_search.minute_interval` setting is undefined