### PR TITLE
fix: fix truncated course title on mobile view

### DIFF
--- a/src/pages/ProgramPage/Secondary/SecondaryProgramBanner.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryProgramBanner.tsx
@@ -37,7 +37,6 @@ const ContentWrapper = styled.div`
   flex-direction: column;
   item-justify: center;
   padding: 10vmin;
-  white-space: nowrap;
   justify-content: space-between;
 
   @media (min-width: ${BREAK_POINT}px) {
@@ -71,11 +70,13 @@ const StyledTitle = styled.h1`
   line-height: 1.23;
   letter-spacing: 1px;
   font-weight: bold;
-  max-width: 240px;
+  max-width: 100%;
+  white-space: normal;
 
   @media (min-width: ${BREAK_POINT}px) {
     font-size: 40px;
     max-width: 520px;
+    white-space: nowrap;
   }
 `
 


### PR DESCRIPTION
修正課程名稱在手機版畫面被截斷的問題，讓完整名稱可以正常顯示。

- Trello 卡片：https://trello.com/c/jyNQ82TN