### PR TITLE
Feat/update meets us form questions

### DIFF
--- a/src/pages/MeetingPage/MeetingPage.tsx
+++ b/src/pages/MeetingPage/MeetingPage.tsx
@@ -176,23 +176,6 @@ const MeetingPage = () => {
         <Heading as="h3" size="lg" className="mb-4 text-center">
           {formatMessage(MeetingPageMessages.MeetingPage.bookingLink, { managerUsername: managerUsername })}
         </Heading>
-        <FormControl className="mb-3" isRequired>
-          <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.name)}</FormLabel>
-          <Input required name="name" placeholder={formatMessage(MeetingPageMessages.MeetingPage.name)} />
-        </FormControl>
-        <FormControl className="mb-3" isRequired>
-          <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.phone)}</FormLabel>
-          <Input required name="phone" placeholder={formatMessage(MeetingPageMessages.MeetingPage.phone)} />
-        </FormControl>
-        <FormControl className="mb-3" isRequired>
-          <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.email)}</FormLabel>
-          <Input
-            required
-            name="email"
-            type="email"
-            placeholder={formatMessage(MeetingPageMessages.MeetingPage.email)}
-          />
-        </FormControl>
         {categoryCheckboxes.length !== 0 ? (
           <FormControl className="mb-3" isRequired>
             <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.interest)}</FormLabel>
@@ -228,6 +211,23 @@ const MeetingPage = () => {
               </Checkbox>
             </Stack>
           </CheckboxGroup>
+        </FormControl>
+        <FormControl className="mb-3" isRequired>
+          <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.name)}</FormLabel>
+          <Input required name="name" placeholder={formatMessage(MeetingPageMessages.MeetingPage.name)} />
+        </FormControl>
+        <FormControl className="mb-3" isRequired>
+          <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.phone)}</FormLabel>
+          <Input required name="phone" placeholder={formatMessage(MeetingPageMessages.MeetingPage.phone)} />
+        </FormControl>
+        <FormControl className="mb-3" isRequired>
+          <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.email)}</FormLabel>
+          <Input
+            required
+            name="email"
+            type="email"
+            placeholder={formatMessage(MeetingPageMessages.MeetingPage.email)}
+          />
         </FormControl>
         <FormControl className="mb-3">
           <FormLabel>{formatMessage(MeetingPageMessages.MeetingPage.introducer)}</FormLabel>


### PR DESCRIPTION
新增與調整 meets/us 表單內容：

1. 新增單選題「你目前的身份是？」（必填）
   - 對應後台欄位：身份
   - 選項：
     - 學生（含應屆畢業）
     - 上班族
     - 準備轉職中
     - 自由工作者 / 接案者
     - 全職家管／待業中

2. 新增單選題「請問您每月的學習預算是？」（必填）
   - 對應後台欄位：每月學習預算
   - 選項：
     - NT$1,000 元以下
     - NT$1,000 ~ 3,000 元
     - NT$3,000 ~ 5,000 元
     - NT$5,000 元以上

3. 調整欄位順序：
   - 將「姓名、電話、Email」欄位調整至「方便聯繫時段」欄位下方，提升使用者填寫流暢度

---

📌 Trello 卡片：[https://trello.com/c/xxxxx（如有請補上）](https://trello.com/c/NJYFyTaI)
