### PR TITLE
fix:setting checkout.approvement boolean and numeric flag recognition

### DIFF
--- a/src/components/checkout/CheckoutBlock.tsx
+++ b/src/components/checkout/CheckoutBlock.tsx
@@ -597,7 +597,7 @@ const CheckoutBlock: React.FC<{
           </div>
         </AdminCard>
       )}
-      {settings['checkout.approvement'] === 'true' && (
+      {(settings['checkout.approvement'] === 'true' || settings['checkout.approvement'] === '1') && (
         <AdminCard className="mb-3">
           <StyledCheckbox
             className="mr-2"
@@ -617,7 +617,10 @@ const CheckoutBlock: React.FC<{
       )}
       <div className="mb-3">
         <CheckoutCard
-          isDisabled={settings['checkout.approvement'] === 'true' && isApproved === false}
+          isDisabled={
+            (settings['checkout.approvement'] === 'true' || settings['checkout.approvement'] === '1') &&
+            isApproved === false
+          }
           check={check}
           cartProducts={cartProducts}
           discountId={discountId}


### PR DESCRIPTION
<img width="1023" height="283" alt="截圖 2025-08-08 中午12 04 59" src="https://github.com/user-attachments/assets/ac4473a2-fa74-492a-b4db-97f96c74c3dc" />

調整在setting中，用true / 1 都能吃到參數