### PR TITLE
feat:cart add product from query string

### DIFF
--- a/src/components/checkout/CoinCheckoutModal.tsx
+++ b/src/components/checkout/CoinCheckoutModal.tsx
@@ -4,11 +4,12 @@ import PriceLabel from 'lodestar-app-element/src/components/labels/PriceLabel'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { validationRegExp } from 'lodestar-app-element/src/helpers'
 import { sum } from 'ramda'
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
+import { StringParam, useQueryParam } from 'use-query-params'
 import { handleError } from '../../helpers'
 import { commonMessages } from '../../helpers/translation'
 import { useCheck } from '../../hooks/checkout'
@@ -111,6 +112,16 @@ const CoinCheckoutModal: React.FC<{
       onOpen()
     }
   }
+
+  const [checkoutProductId] = useQueryParam('checkoutProductId', StringParam)
+  const checkoutOpened = useRef(false)
+
+  useEffect(() => {
+    if (!checkoutOpened.current && checkoutProductId === productId) {
+      checkoutOpened.current = true
+      handleOpen()
+    }
+  }, [checkoutProductId])
 
   return (
     <>

--- a/src/pages/CartPage.tsx
+++ b/src/pages/CartPage.tsx
@@ -8,9 +8,9 @@ import { notEmpty } from 'lodestar-app-element/src/helpers'
 import { useResourceCollection } from 'lodestar-app-element/src/hooks/resource'
 import { getResourceByProductId } from 'lodestar-app-element/src/hooks/util'
 import { groupBy } from 'ramda'
-import React, { useContext, useEffect, useState } from 'react'
+import React, { useContext, useEffect, useRef, useState } from 'react'
 import { useIntl } from 'react-intl'
-import { useLocation } from 'react-router-dom'
+import { useHistory, useLocation } from 'react-router-dom'
 import { StringParam, useQueryParam } from 'use-query-params'
 import CartProductTableCard from '../components/checkout/CartProductTableCard'
 import CheckoutBlock from '../components/checkout/CheckoutBlock'
@@ -20,14 +20,43 @@ import hasura from '../hasura'
 import { checkoutMessages } from '../helpers/translation'
 import { useMember } from '../hooks/member'
 import { CartProductProps } from '../types/checkout'
+import { ProductType } from '../types/product'
 
 const CartPage: React.FC = () => {
   const location = useLocation<{ productUrn?: string }>()
+  const history = useHistory()
   const { formatMessage } = useIntl()
   const [checkoutAlready, setCheckoutAlready] = useState(false)
   const [shopId] = useQueryParam('shopId', StringParam)
-  const { cartProducts: rawCartProducts } = useContext(CartContext)
+  const [productParam] = useQueryParam('product', StringParam)
+  const { cartProducts: rawCartProducts, addCartProduct } = useContext(CartContext)
   const { loading: loadingExistentProducts, data: cartProducts } = useFilterExistentProducts(rawCartProducts)
+
+  // 從 query string 讀取 product 參數，自動加入購物車
+  const isAddingFromUrl = useRef(false)
+  useEffect(() => {
+    if (!productParam || isAddingFromUrl.current || !addCartProduct) return
+
+    // 解析格式：ProgramPlan_{planId}
+    const underscoreIndex = productParam.indexOf('_')
+    if (underscoreIndex === -1) return
+
+    const productType = productParam.substring(0, underscoreIndex) as ProductType
+    const productTarget = productParam.substring(underscoreIndex + 1)
+    if (!productType || !productTarget) return
+
+    isAddingFromUrl.current = true
+    addCartProduct(productType, productTarget).then(() => {
+      // 清除 URL 上的 product 參數，避免重新整理重複加入
+      const searchParams = new URLSearchParams(window.location.search)
+      searchParams.delete('product')
+      const newSearch = searchParams.toString()
+      history.replace({
+        pathname: location.pathname,
+        search: newSearch ? `?${newSearch}` : '',
+      })
+    })
+  }, [productParam, addCartProduct])
   const { id: appId } = useApp()
   const { isAuthenticating, currentMemberId } = useAuth()
   const { loadingMember, member } = useMember(currentMemberId || '')

--- a/src/pages/ProgramPage/Primary/ProgramPlanCard/index.tsx
+++ b/src/pages/ProgramPage/Primary/ProgramPlanCard/index.tsx
@@ -165,6 +165,7 @@ const ProgramPlanCard: React.FC<{
             </Button>
           )}
           defaultProductId={`ProgramPlan_${programPlan.id}`}
+          onAuthRequired={() => setAuthModalVisible?.(true)}
           warningText={
             listPrice <= 0 || (typeof salePrice === 'number' && salePrice <= 0)
               ? formatMessage(productMessages.program.defaults.warningText)
@@ -174,6 +175,7 @@ const ProgramPlanCard: React.FC<{
       ) : enabledModules.group_buying && programPlan.groupBuyingPeople > 1 ? (
         <CheckoutProductModal
           defaultProductId={`ProgramPlan_${programPlan.id}`}
+          onAuthRequired={() => setAuthModalVisible?.(true)}
           renderTrigger={({ isLoading, onOpen }) => (
             <Button
               colorScheme="primary"

--- a/src/pages/ProgramPage/Secondary/SecondaryCoinCheckoutModal.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryCoinCheckoutModal.tsx
@@ -4,11 +4,12 @@ import PriceLabel from 'lodestar-app-element/src/components/labels/PriceLabel'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { validationRegExp } from 'lodestar-app-element/src/helpers'
 import { sum } from 'ramda'
-import React, { useContext } from 'react'
+import React, { useContext, useEffect, useRef } from 'react'
 import { useForm } from 'react-hook-form'
 import { useIntl } from 'react-intl'
 import { useHistory } from 'react-router-dom'
 import styled from 'styled-components'
+import { StringParam, useQueryParam } from 'use-query-params'
 import { AuthModalContext } from '../../../components/auth/AuthModal'
 import checkoutMessages from '../../../components/checkout/translation'
 import CommonModal from '../../../components/common/CommonModal'
@@ -112,6 +113,16 @@ const CoinCheckoutModal: React.FC<{
       onOpen()
     }
   }
+
+  const [checkoutProductId] = useQueryParam('checkoutProductId', StringParam)
+  const checkoutOpened = useRef(false)
+
+  useEffect(() => {
+    if (!checkoutOpened.current && checkoutProductId === productId) {
+      checkoutOpened.current = true
+      handleOpen()
+    }
+  }, [checkoutProductId])
 
   return (
     <>

--- a/src/pages/ProgramPage/Secondary/SecondaryProgramPlanCard/SecondaryPaymentButton.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryProgramPlanCard/SecondaryPaymentButton.tsx
@@ -74,6 +74,7 @@ const SecondaryPaymentButton: React.FC<{
       ) : isSubscription ? (
         <CheckoutProductModal
           defaultProductId={`${type}_${target}`}
+          onAuthRequired={() => setAuthModalVisible?.(true)}
           renderTrigger={({ isLoading, onOpen }) => (
             <StyledSecondaryCartButton
               colorScheme="outline"

--- a/src/pages/ProgramPage/Secondary/SecondaryProgramPlanCard/index.tsx
+++ b/src/pages/ProgramPage/Secondary/SecondaryProgramPlanCard/index.tsx
@@ -176,6 +176,7 @@ const SecondaryProgramPlanCard: React.FC<{
             </SecondaryEnrollButton>
           )}
           defaultProductId={`ProgramPlan_${programPlan.id}`}
+          onAuthRequired={() => setAuthModalVisible?.(true)}
           warningText={
             listPrice <= 0 || (typeof salePrice === 'number' && salePrice <= 0)
               ? formatMessage(productMessages.program.defaults.warningText)
@@ -185,6 +186,7 @@ const SecondaryProgramPlanCard: React.FC<{
       ) : enabledModules.group_buying && programPlan.groupBuyingPeople > 1 ? (
         <CheckoutProductModal
           defaultProductId={`ProgramPlan_${programPlan.id}`}
+          onAuthRequired={() => setAuthModalVisible?.(true)}
           renderTrigger={({ isLoading, onOpen }) => (
             <SecondaryEnrollButton
               isDisabled={(isAuthenticated && isLoading) || !programPlan.publishedAt}


### PR DESCRIPTION
購物車頁面支援從 URL 的 query string自動加入商品。
當使用者從外部頁面（課介頁微服務）點擊「立即購買」跳轉到 /cart?product=ProgramPlan_xxx時，CartPage 會自動解析 product 參數並呼叫 addCartProduct 加入購物車，加入後清除 URL參數避免重複加入。

Cart page supports auto-adding products from URL query string. When a user clicks "Buy Now" from an external page (porgram-share microservice) and is redirected to /cart?product=ProgramPlan_xxx, CartPage automatically parses the product parameter, calls addCartProduct to add the item to the cart, and clears the URL parameter to prevent duplicate additions on refresh. 

