### PR TITLE
fix: filter out cross-app products in cart sync

### DIFF
--- a/src/services/cart/CartOperator.ts
+++ b/src/services/cart/CartOperator.ts
@@ -68,14 +68,16 @@ export abstract class CartOperator {
     })
     const availableProducts = this._removePhaseOutCartProducts(mergedCartProducts, remoteCartProducts?.merchandise_spec)
 
-    this._updateLocalCache(availableProducts)
+    const validProducts = filterByValidProductIds(availableProducts, remoteCartProducts as hasura.GET_CART_PRODUCT_COLLECTION | undefined)
+
+    this._updateLocalCache(validProducts)
 
     try {
       if (this.isLoginStatus()) {
         await this.updateCartProducts({
           variables: {
             memberId: this.currentMemberId || '',
-            cartProductObjects: availableProducts.map(product => {
+            cartProductObjects: validProducts.map(product => {
               const tracking = product?.options?.tracking || {}
               return {
                 app_id: this.appId,
@@ -88,7 +90,7 @@ export abstract class CartOperator {
         })
       }
 
-      this.setCartProducts(availableProducts)
+      this.setCartProducts(validProducts)
     } catch (error) {
       console.error(error)
     }
@@ -150,6 +152,11 @@ export abstract class CartOperator {
         product(where: { id: { _in: $localProductIds } }) {
           id
           type
+          product_owner {
+            member {
+              app_id
+            }
+          }
           product_enrollments(where: { member_id: { _eq: $memberId } }) {
             member_id
             is_physical
@@ -276,4 +283,24 @@ export abstract class CartOperator {
   private _updateLocalCache(filteredProducts: CartProductProps[]) {
     localStorage.setItem('kolable.cart._products', JSON.stringify(filteredProducts))
   }
+}
+
+export function filterByValidProductIds(
+  products: CartProductProps[],
+  remoteCartProducts: any,
+): CartProductProps[] {
+  if (!remoteCartProducts?.product) return products
+
+  // Invalid products have either:
+  // - product_owner = null (no owner, e.g. deleted/orphan products)
+  // - product_owner.member = null (cross-app, filtered by Hasura row-level permissions)
+  const validProductIds = new Set(
+    remoteCartProducts.product
+      .filter((p: any) => p.product_owner && p.product_owner.member)
+      .map((p: any) => p.id),
+  )
+
+  return validProductIds.size > 0
+    ? products.filter(p => validProductIds.has(p.productId))
+    : products
 }


### PR DESCRIPTION
## 問題描述

購物車在 sync 時，會將 localStorage 和 DB 的商品合併，但沒有驗證商品是否屬於當前 app。當 `cart_product` 表中存在跨 app 的商品（例如 `cw` 的方案出現在 `demo` 的購物車），這些商品：

1. 前端 UI 不會顯示（被 `_removePhaseOutCartProducts` 過濾掉）
2. 但仍然保留在 DB 和 localStorage 中
3. 結帳時全部送給 `checkout-order` API
4. 後端查不到跨 app 的方案 → 回傳 `E_CHECKOUT_ORDER`「找不到方案」→ **整批失敗**
5. 前端 `totalPrice = 0`，無法結帳

## 修改內容

在 `CartOperator.syncCartProducts` 中新增 `filterByValidProductIds`，利用 Hasura row-level permissions 的特性來判斷商品是否屬於當前 app：

- 在 `product` GraphQL 查詢中加入 `product_owner.member.app_id`
- 跨 app 商品的 `product_owner` 或 `product_owner.member` 會是 `null`（被 Hasura 權限過濾）
- sync 時自動移除這些無效商品，不寫回 DB 和 localStorage

## 影響範圍

- `src/services/cart/CartOperator.ts`
  - `syncCartProducts`：使用 `filterByValidProductIds` 過濾後再寫入
  - `_createGetCartProductOperationQuery`：`product` 查詢新增 `product_owner { member { app_id } }`
  - 新增 `filterByValidProductIds` 函數

## 測試方式

1. 在 `cart_product` 表中加入跨 app 的商品
2. 開啟購物車頁面，確認跨 app 商品不會出現在購物清單
3. 確認 `checkout-order` API 只收到有效商品的 productIds
4. 確認總價正常顯示，可以選擇付款方式並結帳
