### PR TITLE
fix: prevent deleted cart products from reappearing via race condition

### DIFF
--- a/src/contexts/CartContext.tsx
+++ b/src/contexts/CartContext.tsx
@@ -3,7 +3,7 @@ import { useApp } from 'lodestar-app-element/src/contexts/AppContext'
 import { useAuth } from 'lodestar-app-element/src/contexts/AuthContext'
 import { getConversionApiData } from 'lodestar-app-element/src/helpers/conversionApi'
 import { ConversionApiContent, ConversionApiEvent } from 'lodestar-app-element/src/types/conversionApi'
-import React, { useEffect, useMemo, useState } from 'react'
+import React, { useEffect, useMemo, useRef, useState } from 'react'
 import hasura from '../hasura'
 import { getTrackingCookie } from '../helpers'
 import { useMember } from '../hooks/member'
@@ -39,10 +39,18 @@ export const CartProvider: React.FC = ({ children }) => {
   )
 
   const [cartProducts, setCartProducts] = useState<CartProductProps[]>([])
+  const pendingDeletionIdsRef = useRef<Set<string>>(new Set())
 
   const cartOperationFactory = useMemo(
     () =>
-      new CreateCartOperationContextFactory(apolloClient, appId, currentMemberId, updateCartProducts, setCartProducts),
+      new CreateCartOperationContextFactory(
+        apolloClient,
+        appId,
+        currentMemberId,
+        updateCartProducts,
+        setCartProducts,
+        pendingDeletionIdsRef.current,
+      ),
     [apolloClient, appId, currentMemberId, updateCartProducts],
   )
 

--- a/src/services/cart/CartOperator.ts
+++ b/src/services/cart/CartOperator.ts
@@ -1,5 +1,5 @@
 import { ApolloClient, gql } from '@apollo/client'
-import { uniqBy } from 'ramda'
+import { reject, uniqBy } from 'ramda'
 import hasura from '../../hasura'
 import { CartProductProps } from '../../types/checkout'
 import { CartOperatorEnum } from './CartOperatorEnum'
@@ -22,6 +22,7 @@ export abstract class CartOperator {
   private currentMemberId: string | null
   protected updateCartProducts: (variables: updateCartProductVariables) => Promise<any>
   protected setCartProducts: React.Dispatch<React.SetStateAction<CartProductProps[]>>
+  protected pendingDeletionIds: Set<string>
   protected operator: CartOperatorEnum | undefined
 
   constructor(
@@ -30,12 +31,14 @@ export abstract class CartOperator {
     currentMemberId: string | null,
     updateCartProducts: (variables: updateCartProductVariables) => Promise<any>,
     setCartProducts: React.Dispatch<React.SetStateAction<CartProductProps[]>>,
+    pendingDeletionIds: Set<string>,
   ) {
     this.apolloClient = apolloClient
     this.appId = appId
     this.currentMemberId = currentMemberId
     this.updateCartProducts = updateCartProducts
     this.setCartProducts = setCartProducts
+    this.pendingDeletionIds = pendingDeletionIds
   }
 
   abstract operation(...args: any[]): Promise<void>
@@ -56,6 +59,10 @@ export abstract class CartOperator {
     return !!this.currentMemberId
   }
 
+  protected getPendingDeletionIds(): Set<string> {
+    return this.pendingDeletionIds
+  }
+
   public async syncCartProducts(operation: CartOperatorEnum) {
     const cachedCartProducts = this.getLocalCartProducts()
     const cartProductOptions = this._restructureCachedCartProducts(cachedCartProducts)
@@ -68,14 +75,17 @@ export abstract class CartOperator {
     })
     const availableProducts = this._removePhaseOutCartProducts(mergedCartProducts, remoteCartProducts?.merchandise_spec)
 
-    this._updateLocalCache(availableProducts)
+    const pendingIds = this.getPendingDeletionIds()
+    const finalProducts = reject(product => pendingIds.has(product.productId), availableProducts)
+
+    this._updateLocalCache(finalProducts)
 
     try {
       if (this.isLoginStatus()) {
         await this.updateCartProducts({
           variables: {
             memberId: this.currentMemberId || '',
-            cartProductObjects: availableProducts.map(product => {
+            cartProductObjects: finalProducts.map(product => {
               const tracking = product?.options?.tracking || {}
               return {
                 app_id: this.appId,
@@ -88,7 +98,7 @@ export abstract class CartOperator {
         })
       }
 
-      this.setCartProducts(availableProducts)
+      this.setCartProducts(finalProducts)
     } catch (error) {
       console.error(error)
     }
@@ -119,8 +129,10 @@ export abstract class CartOperator {
         ? `product: { id: { _in: $productIds }, product_owner: { member: { app_id: { _eq: $appId } } } }`
         : ''
 
+    // `PH_` prefix routes this query to the primary Hasura endpoint (read-your-own-writes),
+    // bypassing the read replica's replication lag. See lodestar-app-element/src/helpers/apollo.ts.
     return gql`
-      query GET_CART_PRODUCT_COLLECTION(
+      query PH_GET_CART_PRODUCT_COLLECTION(
         $appId: String!
         $memberId: String!
         $productIds: [String!]
@@ -192,7 +204,7 @@ export abstract class CartOperator {
     cachedCartProducts,
     cartProductOptions,
   }: {
-    remoteCartProducts: hasura.GET_CART_PRODUCT_COLLECTION
+    remoteCartProducts: hasura.PH_GET_CART_PRODUCT_COLLECTION
     cachedCartProducts: any[]
     cartProductOptions: { [ProductId: string]: any }
   }) {
@@ -234,7 +246,7 @@ export abstract class CartOperator {
 
   private _removePhaseOutCartProducts(
     cartProducts: CartProductProps[],
-    merchandiseSpecData?: hasura.GET_CART_PRODUCT_COLLECTION['merchandise_spec'],
+    merchandiseSpecData?: hasura.PH_GET_CART_PRODUCT_COLLECTION['merchandise_spec'],
   ): CartProductProps[] {
     return cartProducts
       .filter(cartProduct => !this._isPhasedOutProduct(cartProduct))
@@ -254,7 +266,7 @@ export abstract class CartOperator {
 
   private _isPublishedMerchandiseSpec(
     cartProduct: CartProductProps,
-    merchandiseSpecData?: hasura.GET_CART_PRODUCT_COLLECTION['merchandise_spec'],
+    merchandiseSpecData?: hasura.PH_GET_CART_PRODUCT_COLLECTION['merchandise_spec'],
   ): boolean {
     if (!cartProduct.productId.startsWith('MerchandiseSpec_')) {
       return true

--- a/src/services/cart/CreateCartOperationContextFactory.ts
+++ b/src/services/cart/CreateCartOperationContextFactory.ts
@@ -14,6 +14,7 @@ export class CreateCartOperationContextFactory {
   private currentMemberId: string | null
   protected updateCartProducts: (variables: any) => Promise<any>
   protected setCartProducts: React.Dispatch<React.SetStateAction<CartProductProps[]>>
+  private pendingDeletionIds: Set<string>
 
   constructor(
     apolloClient: ApolloClient<any>,
@@ -21,12 +22,14 @@ export class CreateCartOperationContextFactory {
     currentMemberId: string | null,
     updateCartProducts: (variables: any) => Promise<any>,
     setCartProducts: React.Dispatch<React.SetStateAction<CartProductProps[]>>,
+    pendingDeletionIds: Set<string>,
   ) {
     this.apolloClient = apolloClient
     this.appId = appId
     this.currentMemberId = currentMemberId
     this.updateCartProducts = updateCartProducts
     this.setCartProducts = setCartProducts
+    this.pendingDeletionIds = pendingDeletionIds
   }
 
   createOperator(operation: CartOperatorEnum): CartOperator {
@@ -50,6 +53,7 @@ export class CreateCartOperationContextFactory {
       this.currentMemberId,
       this.updateCartProducts,
       this.setCartProducts,
+      this.pendingDeletionIds,
     )
   }
 }

--- a/src/services/cart/RemoveCartProductOperator.ts
+++ b/src/services/cart/RemoveCartProductOperator.ts
@@ -41,17 +41,26 @@ export class RemoveCartProductOperator extends CartOperator {
   operator = CartOperatorEnum.REMOVE_CART_PRODUCTS
 
   async operation(productIds: string[]) {
-    const cachedCartProducts = this.getLocalCartProducts()
+    const pending = this.getPendingDeletionIds()
+    productIds.forEach(id => pending.add(id))
 
-    const optimisticCartProducts = reject(cartProduct => productIds.includes(cartProduct.productId), cachedCartProducts)
+    try {
+      const cachedCartProducts = this.getLocalCartProducts()
+      const optimisticCartProducts = reject(
+        cartProduct => productIds.includes(cartProduct.productId),
+        cachedCartProducts,
+      )
 
-    this._updateLocalStorage(optimisticCartProducts)
-    this.setCartProducts(optimisticCartProducts)
+      this._updateLocalStorage(optimisticCartProducts)
+      this.setCartProducts(optimisticCartProducts)
 
-    this._performBackgroundCleanup(productIds, optimisticCartProducts)
+      await this._performCleanup(productIds, optimisticCartProducts)
+    } finally {
+      productIds.forEach(id => pending.delete(id))
+    }
   }
 
-  private async _performBackgroundCleanup(productIds: string[], optimisticCartProducts: CartProductProps[]) {
+  private async _performCleanup(productIds: string[], optimisticCartProducts: CartProductProps[]) {
     try {
       // eslint-disable-next-line @typescript-eslint/no-unused-vars
       const [_, validationData] = await Promise.all([
@@ -70,7 +79,7 @@ export class RemoveCartProductOperator extends CartOperator {
         await this._syncCleanedProducts(cleanedCartProducts)
       }
     } catch (error) {
-      console.error('Background cleanup failed:', error)
+      console.error('Cart cleanup failed:', error)
     }
   }
 


### PR DESCRIPTION
## Summary

刪除購物車最後一個商品後，該商品會在重新整理後（甚至不重新整理時）復活。

**根因**：三個問題疊加
1. `RemoveCartProductOperator._performBackgroundCleanup` 是 fire-and-forget，caller 的 `await` 並沒有真正等 DELETE mutation 完成
2. 此時若另一個 `syncCartProducts(INIT)` 被觸發（例如 auth refresh 或 re-render 讓 `currentMemberId` deps 變化），會從 backend re-fetch `cart_product` 並 merge 回 local + backend
3. Cart 查詢走 RH (read replica) endpoint，replication lag 期間會讀到尚未被 DELETE 清掉的舊資料

## Changes

三道防線：

| 機制 | 檔案 |
|------|------|
| **Pending deletion set**：`useRef<Set<string>>` 追蹤進行中的刪除，`syncCartProducts` 過濾掉這些 ids | `CartContext.tsx`, `CartOperator.ts`, `CreateCartOperationContextFactory.ts`, `RemoveCartProductOperator.ts` |
| **Cart 查詢走 PH endpoint**：`GET_CART_PRODUCT_COLLECTION` → `PH_GET_CART_PRODUCT_COLLECTION`，依 `lodestar-app-element/src/helpers/apollo.ts` 的 split link 規則自動路由到 primary，避開 replication lag | `CartOperator.ts` |
| **Await cleanup**：`RemoveCartProductOperator.operation` 外層 try/finally 保證 pending set 一定被清掉；`_performBackgroundCleanup` → `_performCleanup` 並被 await | `RemoveCartProductOperator.ts` |

同時包含 `hasura.d.ts` 的 typegen regeneration。

## Test plan

- [ ] 登入狀態加入 1 個商品後立即刪除 → UI 不顯示商品
- [ ] 刪除後重新整理 → 商品不復活
- [ ] 刪除後切頁再回購物車 → 商品不復活
- [ ] 快速刪除多個商品（cart 剩 >1 項時連續刪）→ 都不復活
- [ ] 未登入狀態刪除最後一個商品 → 仍正常（pending set 對未登入也生效；只是沒有 backend sync）
- [ ] 結帳流程不受影響（`CheckoutBlock.handleCheckoutAsync` 的清空邏輯）

🤖 Generated with [Claude Code](https://claude.com/claude-code)