### PR TITLE
feat: adopt element v1.95.13 and make the WS endpoint path-only

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -3,9 +3,9 @@
 REACT_APP_API_BASE_ROOT=/api/v1
 REACT_APP_GRAPHQL_PH_ENDPOINT=/gql-w/v1/graphql
 REACT_APP_GRAPHQL_RH_ENDPOINT=/gql-r/v1/graphql
-# TODO(single-domain): switch to /gql-ws/v1/graphql once lodestar-app-element
-# with runtime WS-host derivation (PR #138) is tagged and bumped here
-REACT_APP_GRAPHQL_WS_ENDPOINT=wss://hdb.kolable.com/v1/graphql
+# path-only: element v1.95.13 derives wss://<current-host> at connect time,
+# so one build serves every tenant domain
+REACT_APP_GRAPHQL_WS_ENDPOINT=/gql-ws/v1/graphql
 
 # AWS — canonical host for uploaded-file URLs written to the DB and for
 # recognizing stored URLs; browsers reach the files same-origin via the

--- a/.env.staging
+++ b/.env.staging
@@ -3,9 +3,9 @@
 REACT_APP_API_BASE_ROOT=/api/v1
 REACT_APP_GRAPHQL_PH_ENDPOINT=/gql-w/v1/graphql
 REACT_APP_GRAPHQL_RH_ENDPOINT=/gql-r/v1/graphql
-# TODO(single-domain): switch to /gql-ws/v1/graphql once lodestar-app-element
-# with runtime WS-host derivation (PR #138) is tagged and bumped here
-REACT_APP_GRAPHQL_WS_ENDPOINT=wss://hasura-dev.kolable.com/v1/graphql
+# path-only: element v1.95.13 derives wss://<current-host> at connect time,
+# so one build serves every tenant domain
+REACT_APP_GRAPHQL_WS_ENDPOINT=/gql-ws/v1/graphql
 
 # AWS — canonical host for uploaded-file URLs written to the DB and for
 # recognizing stored URLs; browsers reach the files same-origin via the

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jszip": "^3.10.1",
     "libphonenumber-js": "1.9.34",
     "lodash": "^4.17.15",
-    "lodestar-app-element": "urfit-tech/lodestar-app-element#v1.95.5",
+    "lodestar-app-element": "urfit-tech/lodestar-app-element#v1.95.13",
     "marked": "4.3.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.31",

--- a/yarn.lock
+++ b/yarn.lock
@@ -15957,9 +15957,9 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodestar-app-element@urfit-tech/lodestar-app-element#v1.95.5":
+"lodestar-app-element@urfit-tech/lodestar-app-element#v1.95.13":
   version: 0.1.0
-  resolution: "lodestar-app-element@https://github.com/urfit-tech/lodestar-app-element.git#commit=da7cd8930c76c1138aa32262f0c63e5de0f6c1ca"
+  resolution: "lodestar-app-element@https://github.com/urfit-tech/lodestar-app-element.git#commit=894565565b59218ca840e37f3a22ea2b955877db"
   dependencies:
     "@apollo/client": "npm:^3.7.11"
     "@babel/cli": "npm:^7.13.16"
@@ -16039,7 +16039,7 @@ __metadata:
     use-tw-zipcode: "npm:^2.0.4"
     uuid: "npm:8.3.2"
     xss: "npm:^1.0.10"
-  checksum: 10c0/83d943a5dc0aacd6695dce178ef287d7a6f5c84b2bb7d330828a0beed9879daf2c8ae7b7b0050dae8a523ae85a92f2ec3e8b6b731acbc37256c2a4d24134ed6e
+  checksum: 10c0/b8fd3b105b9402b30959b75aba1514bad5f68d907855f28b4be8d8fda0793621ae19b259efb90cbd12750b0db31a612df211162732935ca02d9fce03bbeac9cb
   languageName: node
   linkType: hard
 
@@ -16130,7 +16130,7 @@ __metadata:
     libphonenumber-js: "npm:1.9.34"
     lint-staged: "npm:10.5.4"
     lodash: "npm:^4.17.15"
-    lodestar-app-element: "urfit-tech/lodestar-app-element#v1.95.5"
+    lodestar-app-element: "urfit-tech/lodestar-app-element#v1.95.13"
     marked: "npm:4.3.0"
     moment: "npm:^2.30.1"
     moment-timezone: "npm:^0.5.31"


### PR DESCRIPTION
單一網域改造的最後一塊：訂閱（WebSocket）與資料庫內存的圖片網址，是僅存還指向 `*.kolable.com` 的兩項。

## 變更

| 項目 | 內容 |
|---|---|
| `lodestar-app-element` | `v1.95.5` → **`v1.95.13`** |
| `REACT_APP_GRAPHQL_WS_ENDPOINT` | `wss://hdb…` / `wss://hasura-dev…` → **`/gql-ws/v1/graphql`**（staging 與 production 皆同） |
| `yarn.lock` | 以 **Yarn 4.15.0**（mise 指定版本）重新解析，diff 僅 4 行 |

## 為什麼是 v1.95.13 而不是 v1.95.0

`v1.95.13` = `v1.95.12` + 單一網域的兩個 commit，**開在 v1.95.x 維護線上**（`apollo.ts` 與 master 的 v1.97.0 逐位元相同）。若直接跳 v1.97.0，會一併帶進 master 線上的 shared HTTP client 與 cached app bootstrap 改寫（28 檔、+1124/−310），與本次要驗證的東西混在一起。

本 PR 實際帶進 develop 的僅 **4 個 commit / 4 個檔案 / +56−11**：PaymentSelector fallback、PayUni gateway，以及我們的兩個。

## 驗證

- WebSocket 實測（staging）：`wss://qiuzhen.kolable.dev/gql-ws/v1/graphql` 回 **101 Switching Protocols**，`graphql-transport-ws` 協商成功，Hasura keepalive 正常
- `tsc --noEmit`：`src/` 無錯誤
- **完整 staging build 通過**，產出的 bundle 內含路徑式 WS 端點與網址對應邏輯

## ⚠️ 部署後預期現象與後續

1. **staging 的 craft 圖片會破圖** —— DB 內的網址指向正式 bucket（`static.kolable.com`），經對應後改走 `/files`，而 staging 後端讀的是 `static-dev` bucket，該 bucket 沒有這些檔案（已實測 404）。**正式環境不受影響**（讀正式 bucket）。這是 staging 環境本身的資料落差，不是程式問題。
2. **負載測試需重跑** —— DB 圖片（qiuzhen 首頁約 14 張）自此改由 ECS 提供，先前的容量數據不再適用。
3. 建議把後端的 `GRAPHQL_WS_ENDPOINT` 明確設值（目前為空字串，靠 fallback 到 `phdb` 才能運作；ECS task definition 改設定即可，不需重 build image）。

## 給後續開發者的提醒

本 repo 由 `mise.toml` 指定 **yarn 4.15.0（Berry）**，`yarn.lock` 為 Berry 格式，CI 跑 `yarn install --immutable`。動相依前請先 `corepack prepare yarn@4.15.0 --activate`；誤用 yarn 1 classic 會把整份 lockfile 改寫成 v1 格式（4 萬行 diff）並導致 CI 失敗。

## 合併順序

本 PR 進 `develop` 後，照慣例 merge `develop` → `release` 部署 staging 驗證。

🤖 Generated with [Claude Code](https://claude.com/claude-code)