### PR TITLE
fix: bump element to v1.95.14 to restore stored-image display

### DIFF
--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "jszip": "^3.10.1",
     "libphonenumber-js": "1.9.34",
     "lodash": "^4.17.15",
-    "lodestar-app-element": "urfit-tech/lodestar-app-element#v1.95.13",
+    "lodestar-app-element": "urfit-tech/lodestar-app-element#v1.95.14",
     "marked": "4.3.0",
     "moment": "^2.30.1",
     "moment-timezone": "^0.5.31",
@@ -201,5 +201,6 @@
       "last 1 firefox version",
       "last 1 safari version"
     ]
-  }
+  },
+  "packageManager": "yarn@4.15.0+sha512.07ec708ac11e2eaa4ea2b04cfbb272812f7e74a753f1595eaef4486c663a98306a30cca3e6fc40f7a0b168dcfb3a2490b6a5e0501e20fb69cc36f563dd161c53"
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -15957,7 +15957,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"lodestar-app-element@urfit-tech/lodestar-app-element#v1.95.13":
+"lodestar-app-element@urfit-tech/lodestar-app-element#v1.95.14":
   version: 0.1.0
   resolution: "lodestar-app-element@https://github.com/urfit-tech/lodestar-app-element.git#commit=894565565b59218ca840e37f3a22ea2b955877db"
   dependencies:
@@ -16039,7 +16039,7 @@ __metadata:
     use-tw-zipcode: "npm:^2.0.4"
     uuid: "npm:8.3.2"
     xss: "npm:^1.0.10"
-  checksum: 10c0/b8fd3b105b9402b30959b75aba1514bad5f68d907855f28b4be8d8fda0793621ae19b259efb90cbd12750b0db31a612df211162732935ca02d9fce03bbeac9cb
+  checksum: 10c0/77be810c814b0b853cd17898a74f4781d8f94fb62b4ef9225611d1988b20042801e21955da1a0fa2ba5dba0e2e7fe854cf20d6e36b0dcd590a8130d1f2d73824
   languageName: node
   linkType: hard
 
@@ -16130,7 +16130,7 @@ __metadata:
     libphonenumber-js: "npm:1.9.34"
     lint-staged: "npm:10.5.4"
     lodash: "npm:^4.17.15"
-    lodestar-app-element: "urfit-tech/lodestar-app-element#v1.95.13"
+    lodestar-app-element: "urfit-tech/lodestar-app-element#v1.95.14"
     marked: "npm:4.3.0"
     moment: "npm:^2.30.1"
     moment-timezone: "npm:^0.5.31"


### PR DESCRIPTION
修復 UAT 全站圖片破圖。

## 問題

v1.95.13 帶進的顯示層網址對應，會無條件把 `static.kolable.com` 與 `static-dev.kolable.com` 兩個 host 改寫成 `/files/...`。但 `/files` 只從「該後端設定的那一個 bucket」取檔。

staging 的資料庫圖片網址指向**正式 bucket**，而 staging 後端讀 `static-dev` —— 對應上線後，UAT 站所有 DB 來源圖片（課程封面、craft 圖片）全部 404 破圖。已實測確認：同一個 key 在正式 bucket 200、在 staging bucket 404。

## 修法

element `v1.95.14`（urfit-tech/lodestar-app-element#139，已 merge 進 master 並 backport 到 v1.95.x 線）改由 `REACT_APP_S3_BUCKET` 推導可改寫的 host：

| build | `static.kolable.com/…` | `static-dev.kolable.com/…` |
|---|---|---|
| production | → `/files/…` | 維持絕對 |
| staging | 維持絕對 | → `/files/…` |
| 變數未設定 | no-op | no-op |

**正式環境行為不變**（DB 網址本來就在正式 bucket，仍同源化）；staging 破圖恢復成對應上線前的跨網域載入。

## 附帶變更

`package.json` 多了 `packageManager: yarn@4.15.0+sha512…` —— Yarn 4 在 install 時自動寫入。建議保留：它讓 corepack 自動選對版本，正好防止「誤用 yarn 1 classic 把整份 lockfile 改寫成 v1 格式」這個坑（本次改動前才踩過）。與 `mise.toml` 指定的版本一致。不想要的話刪掉這一行即可。

## 驗證

- lockfile checksum 於 `node:18` 容器內產生（git 相依的 checksum 跨平台不同，Windows 產的會讓 CI 出 `YN0018`）
- 同容器內 `yarn install --immutable` 通過（等同 CI 的檢查）
- 對應邏輯四種情境逐案驗證（正式/測試 build × 正式/測試 bucket 網址），含富文本內嵌多網址的情況

🤖 Generated with [Claude Code](https://claude.com/claude-code)