### PR TITLE
fix: re-resolve element lockfile entry to the actual v1.95.14 commit

### DIFF
--- a/yarn.lock
+++ b/yarn.lock
@@ -15959,7 +15959,7 @@ __metadata:
 
 "lodestar-app-element@urfit-tech/lodestar-app-element#v1.95.14":
   version: 0.1.0
-  resolution: "lodestar-app-element@https://github.com/urfit-tech/lodestar-app-element.git#commit=894565565b59218ca840e37f3a22ea2b955877db"
+  resolution: "lodestar-app-element@https://github.com/urfit-tech/lodestar-app-element.git#commit=c44a0ae2cb5ac3707d641002ccc8af1e921b17b7"
   dependencies:
     "@apollo/client": "npm:^3.7.11"
     "@babel/cli": "npm:^7.13.16"
@@ -16039,7 +16039,7 @@ __metadata:
     use-tw-zipcode: "npm:^2.0.4"
     uuid: "npm:8.3.2"
     xss: "npm:^1.0.10"
-  checksum: 10c0/77be810c814b0b853cd17898a74f4781d8f94fb62b4ef9225611d1988b20042801e21955da1a0fa2ba5dba0e2e7fe854cf20d6e36b0dcd590a8130d1f2d73824
+  checksum: 10c0/0bf6c067d58aba39f5a21790dc7fac15be22907c79e750e032710432b33eeea0a10cb81aa635feb3f92700490639a5e9d621c9b11f8bf9a366e94b98768b7803
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
UAT 圖片仍然破圖的真正原因。

## 問題

前一次升版（#735）我手動把 `yarn.lock` 的 descriptor 從 `#v1.95.13` 改成 `#v1.95.14`，但**保留了原本的 `resolution:` 行**。Yarn 看到條目已完整，直接沿用舊的 resolution，因此實際安裝的仍是 v1.95.13：

```
"lodestar-app-element@urfit-tech/lodestar-app-element#v1.95.14":
  resolution: "...#commit=8945655..."   ← v1.95.13 的 commit
```

結果：`package.json` 與 descriptor 都寫 v1.95.14，但 build 出來的 bundle 仍帶舊的對應規則
（`/https:\/\/static(-dev)?\.kolable\.com\//g`），UAT 圖片照樣 404。已於部署後的 bundle 內直接確認。

## 修法

把整個條目刪掉，讓 Yarn 真正重新解析 tag：

```
resolution: "...#commit=c44a0ae..."   ← v1.95.14
```

## 驗證（皆於 node:18 容器內執行）

- `yarn install --immutable` 通過
- 安裝後的 `node_modules/lodestar-app-element/src/helpers/apollo.ts` 確認含新的 `REACT_APP_S3_BUCKET` 推導邏輯，且舊的寫死 pattern 已為 0

## 教訓

git 相依不能手改 descriptor —— `resolution:` 才是 Yarn 認的來源。升版請改 `package.json` 後刪掉該條目再 install，或直接用 `yarn up`。

🤖 Generated with [Claude Code](https://claude.com/claude-code)